### PR TITLE
Update foot.js 錐効果に対してエクスピアティオの補正が効かない問題の対応

### DIFF
--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -22175,6 +22175,14 @@ g_ITEM_SP_SKILL_CAST_TIME_value_forCalcData = w;
 				// 錐効果値を計算
 				n_A_QUAKE_KIRI = mobData[MONSTER_DATA_INDEX_DEF_DIV_IGNORE_BUFF] * (100 - ignoreDef) / 100.0 / 2;
 
+				// エクスピアティオの効果で補正する
+				if (g_confDataSanzi[CCharaConfSanzi.CONF_ID_EXPIATIO] > 0) {
+					n_A_QUAKE_KIRI -= (n_A_QUAKE_KIRI * ((20 * g_confDataSanzi[CCharaConfSanzi.CONF_ID_EXPIATIO]) / 100));
+				}
+				else if (UsedSkillSearch(SKILL_ID_EXPIATIO)) {
+					n_A_QUAKE_KIRI -= (n_A_QUAKE_KIRI * ((20 * UsedSkillSearch(SKILL_ID_EXPIATIO)) / 100));
+				}
+
 				// 負数だと、floor 処理での丸め仕様が違うようなので。また、IE では Math.sign() 未サポート
 				n_A_QUAKE_KIRI = (n_A_QUAKE_KIRI >= 0 ? 1 : -1) * Math.floor(Math.abs(n_A_QUAKE_KIRI));
 


### PR DESCRIPTION
対策を行ってみました
これで、総合的に錐に対してエクスピアティオのLv x 20%で補正がかかります
