### PR TITLE
概算攻撃回数の計算を修正

### DIFF
--- a/ro4/m/js/CBattleCalcResultAll.js
+++ b/ro4/m/js/CBattleCalcResultAll.js
@@ -16,7 +16,6 @@ const instobject = class {
 		this.maxhit = 0;//スキル１回分のhit回数
 		this.skillinterval = 0.0;
 		this.undertime = 0.0;
-		this.child = null;
 	}
 
 	init(depth, maxcount, starttime, casttime, delay, cooltime, lifetime, interval) {
@@ -70,8 +69,7 @@ const instobject = class {
 			}
 			//インターバル１個増やしたら、次のオブジェクトができる時間に届いたか超えた
 			if ((this.starttime + this.skillinterval) <= t0) {
-				this.child = new instobject();
-				InstObjArray.push(this.child);
+				InstObjArray.push(new instobject());
 				InstObjArray[InstObjArray.length-1].init(this.depth+1, this.maxcount, this.starttime + this.skillinterval, this.casttime, this.delay, this.cooltime, this.lifetime, this.interval);
 				if (InstObjArray[InstObjArray.length-1].exec() == true) {
 					return true;//終了

--- a/ro4/m/js/CBattleCalcResultAll.js
+++ b/ro4/m/js/CBattleCalcResultAll.js
@@ -61,7 +61,7 @@ const instobject = class {
 		var t0;
 
 		//コールスタック安全装置
-		if (this.depth == 4000) {
+		if (this.depth >= 4000) {
 			InstObjIsApproximate = true;
 			InstObjFinalTime = this.starttime;
 			InstObjFinalCount = this.getTotalCount();

--- a/ro4/m/js/CBattleCalcResultAll.js
+++ b/ro4/m/js/CBattleCalcResultAll.js
@@ -340,7 +340,7 @@ function CBattleCalcResultAll () {
 
 	/**
 	 * １HITごとの攻撃間隔の取得.
-	 * @return 概算攻撃間隔
+	 * @return １HITごとの攻撃間隔（秒）
 	 */
 	this.GetHitInterval = function () {
 
@@ -380,7 +380,7 @@ function CBattleCalcResultAll () {
 
 	/**
 	 * 変動＋固定詠唱時間の取得.
-	 * @return 概算攻撃間隔
+	 * @return 変動＋固定詠唱時間（秒）
 	 */
 	this.GetCastTime = function () {
 
@@ -401,7 +401,7 @@ function CBattleCalcResultAll () {
 
 	/**
 	 * オブジェクト維持時間を返す.
-	 * @return 概算攻撃間隔
+	 * @return オブジェクト維持時間（秒）
 	 */
 	this.GetLifeTime = function () {
 		var resultWork = null;
@@ -423,7 +423,7 @@ function CBattleCalcResultAll () {
 	
 	/**
 	 * ディレイまたはクールタイムがオブジェクト維持時間より小さい場合に、その時間を返す.
-	 * @return 概算攻撃間隔
+	 * @return ディレイまたはクールタイムがオブジェクト維持時間より小さい場合の時間（秒）
 	 */
 	this.GetUnderLifeTime = function () {
 		var resultWork = null;
@@ -455,7 +455,7 @@ function CBattleCalcResultAll () {
 
 	/**
 	 * ディレイまたはクールタイムがオブジェクト維持時間より大きい場合に、その時間を返す.
-	 * @return 概算攻撃間隔
+	 * @return ディレイまたはクールタイムがオブジェクト維持時間より大きい場合の時間（秒）
 	 */
 	this.GetOverLifeTime = function () {
 		var resultWork = null;
@@ -870,20 +870,6 @@ function CBattleCalcResultAll () {
 	 */
 	this.GetAttackSecondSummaryMinInterval = function () {
 		var dmg = this.GetDamageSummaryMaxPerAtk();
-		//var instobjlist = [];
-
-		//InstObjArray = new Array();
-		//var foo1 = new fooclass();
-		//foo1.init(1,3,5);
-		//foo1.setZ = 30;
-		//console.log('<<<<< foo1.getZ=%f, mul=%f >>>>>', foo1.getZ, foo1.multiply(5));
-
-		//InstObjFinalTime = 0.0;
-		//var instobj1 = new instobject();
-		//instobj1.init(0, 12, 0.0, 0.0, 0.0, 1.0, 3.5, 0.5);
-		//InstObjArray.push(instobj1);
-		//InstObjArray[0].exec();
-		//console.log('[[[[[ InstObjFinalTime=%f ]]]]]', InstObjFinalTime);
 
 		if (dmg <= 0) {
 			return "（計測不能）";


### PR DESCRIPTION
・ディレイとクールタイムがオブジェクト維持時間に対して短く、複数個の設置オブジェクトが重複して存在する場合に対応しました。



































































