### PR TITLE
スキルの詠唱・ディレイを修正

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -10195,7 +10195,7 @@ g_bUnknownCasts = true;
 			// SPL補正
 			wbairitu += 5 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
 			// 護符修練 補正
-			wbairitu += 15 * n_A_ActiveSkillLV * UsedSkillSearch(SKILL_ID_GOFU_SHUREN);
+			wbairitu += 5 * n_A_ActiveSkillLV * UsedSkillSearch(SKILL_ID_GOFU_SHUREN);
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -9040,26 +9040,17 @@ g_bUnknownCasts = true;
 			wbairitu *= n_A_BaseLV / 100;
 			break;
 
+		// 「アークメイジ」スキル「デッドリープロジェクション」
 		case SKILL_ID_DEADLY_PROJECTION:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// 詠唱時間等
-			/*
-			// 未実測
 			wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-			*/
-
 			// 基本倍率
 			wbairitu = 2000 + (500 * n_A_ActiveSkillLV);
-
 			// SPL補正
 			wbairitu += 15 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;
@@ -9237,29 +9228,19 @@ g_bDefinedDamageIntervals = true;
 			}
 			break;
 
+		// 「アークメイジ」スキル「ソウルバルカンストライク」
 		case SKILL_ID_SOUL_VULKUN_STRIKE:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// 詠唱時間等
-			/*
-			// 未実測
 			wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-			*/
-
 			// 基本倍率
 			wbairitu = 350 + (50 * n_A_ActiveSkillLV);
-
 			// SPL補正
 			wbairitu += 2 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
-
 			// ヒット数
 			wHITsuu = 2 + n_A_ActiveSkillLV;
 			break;
@@ -9547,85 +9528,57 @@ g_bDefinedDamageIntervals = true;
 
 			break;
 
+		// 「アークメイジ」スキル「ロックダウン」
 		case SKILL_ID_ROCK_DOWN:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// クライマックス状態のレベルを取得
 			sklLvSub = UsedSkillSearch(SKILL_ID_CLIMAX);
-
 			// 詠唱時間等
-			/*
-			// 未実測
 			wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-			*/
-
 			// 基本倍率
 			wbairitu = 2000 + (500 * n_A_ActiveSkillLV);
 			if (sklLvSub > 0) {
 				wbairitu *= 3;
 			}
-
 			// SPL補正
 			wbairitu += 15 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;
 
+		// 「アークメイジ」スキル「ストームキャノン」
 		case SKILL_ID_STORM_CANNON:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// クライマックス状態のレベルを取得
 			sklLvSub = UsedSkillSearch(SKILL_ID_CLIMAX);
-
 			// 詠唱時間等
-			/*
-			// 未実測
 			wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-			*/
-
 			// 基本倍率
 			wbairitu = 2000 + (500 * n_A_ActiveSkillLV);
 			if (sklLvSub > 0) {
 				wbairitu *= 3;
 			}
-
 			// SPL補正
 			wbairitu += 15 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;
 
+		//「アークメイジ」スキル「クリムゾンアロー」			
 		case SKILL_ID_CRYMSON_ARROW:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// クライマックス状態のレベルを取得
 			sklLvSub = UsedSkillSearch(SKILL_ID_CLIMAX);
-
 			// 初段ＨＩＴの場合
 			if (battleCalcInfo.parentSkillId === undefined) {
-
 				// 詠唱時間等
-				/*
-				// 未実測
 				wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 				n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 				n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 				n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-				*/
 
 				// 基本倍率
 				wbairitu = (100 * n_A_ActiveSkillLV);
@@ -9636,20 +9589,14 @@ g_bUnknownCasts = true;
 				// ベースレベル補正
 				// TODO: 初段には乗らないのではないかと仮定
 			}
-
-
 			// 追撃の場合
 			else {
-
 				// 基本倍率
 				wbairitu = 1500 + (500 * n_A_ActiveSkillLV);
-
 				// SPL補正
 				wbairitu += 15 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 				// ベースレベル補正
 				wbairitu *= n_A_BaseLV / 100;
-
 				// 攻撃回数
 				if (sklLvSub > 0) {
 					wHITsuu = 3;
@@ -9657,32 +9604,22 @@ g_bUnknownCasts = true;
 			}
 			break;
 
+		//「アークメイジ」スキル「フローズンスラッシュ」
 		case SKILL_ID_FROZEN_SLASH:
-
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
-
 			// クライマックス状態のレベルを取得
 			sklLvSub = UsedSkillSearch(SKILL_ID_CLIMAX);
-
 			// 詠唱時間等
-			/*
-			// 未実測
 			wCast = g_skillManager.GetCastTimeVary(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_KoteiCast = g_skillManager.GetCastTimeFixed(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[2] = g_skillManager.GetDelayTimeCommon(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
 			n_Delay[7] = g_skillManager.GetCoolTime(battleCalcInfo.skillId, battleCalcInfo.skillLv, charaData);
-			*/
-
 			// 基本倍率
 			wbairitu = 2000 + (500 * n_A_ActiveSkillLV);
 			if (sklLvSub > 0) {
 				wbairitu *= 3;
 			}
-
 			// SPL補正
 			wbairitu += 15 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
-
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;
@@ -10231,6 +10168,7 @@ g_bUnknownCasts = true;
 			wbairitu *= n_A_BaseLV / 100;
 			break;
 
+		// 「ソウルアセティック」スキル「青龍符」
 		case SKILL_ID_SEIRYU_FU:
 
 			// TODO: 詠唱時間等未実測スキル
@@ -10257,7 +10195,7 @@ g_bUnknownCasts = true;
 			// SPL補正
 			wbairitu += 5 * GetTotalSpecStatus(MIG_PARAM_ID_SPL);
 			// 護符修練 補正
-			wbairitu += 5 * n_A_ActiveSkillLV * UsedSkillSearch(SKILL_ID_GOFU_SHUREN);
+			wbairitu += 15 * n_A_ActiveSkillLV * UsedSkillSearch(SKILL_ID_GOFU_SHUREN);
 			// ベースレベル補正
 			wbairitu *= n_A_BaseLV / 100;
 			break;

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -32140,10 +32140,6 @@ function CSkillManager() {
 		this.dataArray[skillId] = skillData;
 		skillId++;
 
-
-
-
-
 		// ----------------------------------------------------------------
 		// デッドリープロジェクション
 		// ----------------------------------------------------------------
@@ -32151,7 +32147,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)デッドリープロジェクション";
 			this.kana = "テツトリイフロシエクシヨン";
@@ -32159,6 +32154,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_UNDEAD;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 2000;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500 + 200 * skillLv;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 3000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 5000;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -32265,7 +32275,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)ソウルバルカンストライク";
 			this.kana = "ソウルハルカンストライク";
@@ -32273,6 +32282,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_PSYCO;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 2000;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500 + 200 * skillLv;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 1000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 500;
+			}				
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -32417,7 +32441,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)ロックダウン";
 			this.kana = "ロツクタウン";
@@ -32425,6 +32448,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_EARTH;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return -500 + 1400 * skillLv;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 4000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 500;
+			}				
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -32436,7 +32474,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)ストームキャノン";
 			this.kana = "ストオムキヤノン";
@@ -32444,6 +32481,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_WIND;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return -500 + 1400 * skillLv;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 4000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 500;
+			}	
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -32455,7 +32507,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)クリムゾンアロー";
 			this.kana = "クリムソンアロオ";
@@ -32463,6 +32514,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_FIRE;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return -500 + 1400 * skillLv;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 4000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 500;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -32482,6 +32548,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_FORCE_WATER;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return -500 + 1400 * skillLv;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return 500;
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 4000;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 500;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35502,6 +35583,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35513,7 +35609,6 @@ function CSkillManager() {
 		skillData = new function() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
-
 			this.id = skillId;
 			this.name = "(×)青龍符";
 			this.kana = "セイリユウフ";
@@ -35521,6 +35616,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35540,6 +35650,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35559,6 +35684,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35578,6 +35718,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35597,6 +35752,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35616,6 +35786,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -35635,6 +35820,21 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_LONG;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeVary = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CastTimeFixed = function(skillLv, charaDataManger) {
+				return (0 * skillLv);
+			}
+			this.DelayTimeCommon = function(skillLv, charaDataManger) {
+				return 0;
+			}
+			this.CoolTime = function(skillLv, charaDataManger) {
+				return 0;
+			}			
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -8833,9 +8833,26 @@ g_ITEM_SP_SKILL_CAST_TIME_value_forCalcData = w;
 		// 「ウォーロック　ラディウス」の効果
 		//----------------------------------------------------------------
 		if (UsedSkillSearch(SKILL_ID_RADIUS) > 0) {
-			chkary.push(5 + 5 * UsedSkillSearch(SKILL_ID_RADIUS));
+			switch (attackMethodConf.skillId) {
+				case SKILL_ID_SOUL_EXPANSION:
+				case SKILL_ID_FROST_MISTY:
+				case SKILL_ID_JACK_FROST:
+				case SKILL_ID_DRAIN_LIFE:
+				case SKILL_ID_CRYMSON_ROCK:
+				case SKILL_ID_HELL_INFERNO:
+				case SKILL_ID_COMMET:
+				case SKILL_ID_CHAIN_LIGHTNING:
+				case SKILL_ID_EARTH_STRAIN:
+				case SKILL_ID_TETRA_BOLTEX:
+				case SKILL_ID_SUMMON_FIRE_BALL:
+				case SKILL_ID_SUMMON_WATER_BALL:
+				case SKILL_ID_SUMMON_LIGHTNING_BALL:
+				case SKILL_ID_SUMMON_STONE:
+					chkary.push(5 + 5 * UsedSkillSearch(SKILL_ID_RADIUS));
+			}
 		}
 
+		// ラフィネスタッフの精錬値による効果
 		if (EquipNumSearchMIG(1329)) {
 			chkary.push(n_A_Weapon_ATKplus);
 		}


### PR DESCRIPTION
#207

## スキルの詠唱・ディレイを修正
- クリムゾンアロー
- フローズンスラッシュ
- ストームキャノン
- ロックダウン
- ソウルバルカンストライク
- デッドリープロジェクション

## スキルの効果を修正
- ラディウス
アークメイジスキルにも固定詠唱減少効果が掛かっていた問題
ウォーロックスキルのみに適用されるように修正済み
