### PR TITLE
魔法スキルのダメージ表示が負数になる場合の修正

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -16623,7 +16623,7 @@ function ApplyMagicalSkillDamageRatioChange(battleCalcInfo, charaData, specData,
 	}
 	*/
 
-	return wBMC2;
+	return (wBMC2 >= 0) ? wBMC2 : 0;
  }
 
 /**


### PR DESCRIPTION
Mobの属性が３位上の場合に同属性での魔法スキルによるダメージが負数になるのを０になるよう修正しました。

ApplyElementRatio() が属性倍率を計算していますが、そちらは負数の結果を用いて使用される場合も有り得るのでそのままとし、ダメージの計算をしている ApplyMagicalSkillDamageRatioChange() を修正しました。