### PR TITLE
アイテム・カードをキーボードで素早く操作できるようにする修正案１

### DIFF
--- a/jquery/select2/select2.custom.js
+++ b/jquery/select2/select2.custom.js
@@ -1,3 +1,9 @@
+select2_mode = true;
+function ChangeSlect2Mode() {
+    select2_mode = !select2_mode;
+    LoadSelect2();
+}
+
 const SEARCHABLE_SELECT_LIST = [
     '#OBJID_SELECT_JOB',
     '#OBJID_ARMS_RIGHT',
@@ -33,16 +39,26 @@ const SEARCHABLE_SELECT_LIST = [
 $.fn.select2.defaults.set("dropdownAutoWidth", "true");
 $.fn.select2.defaults.set("width", "auto");
 $.fn.select2.defaults.set("minimumResultsForSearch", "12");
+
 function LoadSelect2() {
     SEARCHABLE_SELECT_LIST.forEach((select_id) => {
         $(select_id).select2();
-        // 同一スロットがカードとエンチャントに利用される場合があるので、スロットの状態によって検索機能をON/OFFする
-        var isEnchant = $(select_id + ' option:contains(エンチャントなし)').length > 0;
-        if (isEnchant) {
-            $(select_id).select2('destroy');
-        };
+        // Select2が無効化されている場合は職を除く全ての検索機能をOFFにする
+        if (!select2_mode) {
+            if (select_id != '#OBJID_SELECT_JOB') {
+                $(select_id).select2('destroy');
+            }
+        }
+        else {
+            // 同一スロットがカードとエンチャントに利用される場合があるので、スロットの状態によって検索機能をON/OFFする
+            var isEnchant = $(select_id + ' option:contains(エンチャントなし)').length > 0;
+            if (isEnchant) {
+                $(select_id).select2('destroy');
+            };
+        }
     });
 };
+
 // 以下のエレメントの状態が変化した時に select2 の UI を更新する
 // UI に異常がある場合はここで適切なエレメントが指定されているかチェックして下さい
 const INIT_TRIGGER_LIST = [
@@ -59,11 +75,13 @@ const INIT_TRIGGER_LIST = [
     '#OBJID_ACCESSARY_1',
     '#OBJID_ACCESSARY_2',
 ];
+
 $(function(){
     $(INIT_TRIGGER_LIST.join(',')).on("select2:select", ()=>{
         LoadSelect2();
     })
 });
+
 $(document).ready(function() {
     $('.OBJID_MONSTER_MAP_CATEGORY').select2();
     $('.OBJID_MONSTER_MAP_MAP').select2();

--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -672,6 +672,9 @@
 										<td ColSpan="10" Bgcolor="#DDDDFF">
 											<input type="button" id="OBJID_SLOT_MODE_BUTTON" value="入力欄切替" onclick="OnClickSlotModeButton() | LoadSelect2()">
 											カードの入力とランダムオプションの入力を切り替えます
+											<br>
+											<input type="button" id=""OBJID_SELECT_MODE_BUTTON" value="選択欄能替" onclick="ChangeSlect2Mode()">
+											アイテム・カード選択欄の検索機能をON/OFF切り替えします
 										</td>
 									</tr>
 

--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -673,7 +673,7 @@
 											<input type="button" id="OBJID_SLOT_MODE_BUTTON" value="入力欄切替" onclick="OnClickSlotModeButton() | LoadSelect2()">
 											カードの入力とランダムオプションの入力を切り替えます
 											<br>
-											<input type="button" id=""OBJID_SELECT_MODE_BUTTON" value="選択欄能替" onclick="ChangeSlect2Mode()">
+											<input type="button" id=""OBJID_SELECT_MODE_BUTTON" value="選択欄切替" onclick="ChangeSlect2Mode()">
 											アイテム・カード選択欄の検索機能をON/OFF切り替えします
 										</td>
 									</tr>


### PR DESCRIPTION
「（旧らとりお仕様と同様）」というリクエストを忠実に実現する案です
Select2を有効化したうえで解決策を考えるよりも簡単なので #274 の比較対象としてPRしておきます

#265
