### PR TITLE
アイテム・カードをキーボードで素早く操作できるようにする修正案２

### DIFF
--- a/jquery/select2/select2.custom.js
+++ b/jquery/select2/select2.custom.js
@@ -30,19 +30,68 @@ const SEARCHABLE_SELECT_LIST = [
     '#OBJID_ACCESSARY_2_CARD_1',
     '#OBJID_ACCESSARY_2_CARD_4',
 ];
+
+// Select2 オプション設定
 $.fn.select2.defaults.set("dropdownAutoWidth", "true");
 $.fn.select2.defaults.set("width", "auto");
 $.fn.select2.defaults.set("minimumResultsForSearch", "12");
+
+// 指定されたSelect2オブジェクトを上下キーで選択を切り替えられるようにカスタマイズ
+function CustomizeSelect2Specify(select_id) {
+    $('#select2-' + select_id.slice(1) + '-container').parent().on('keydown', function(e) {
+        var current_id = $(select_id).prop('selectedIndex');
+        var optionsCount = $(select_id + ' option').length;
+        switch (e.which) {
+            case 38:    // KEY_UP
+            case 40:    // KEY_DOWN
+            case 36:    // HOME
+            case 35:    // END
+                e.preventDefault();
+                if (e.which == 38) {
+                    $(select_id).prop('selectedIndex', Math.max(0, current_id - 1));
+                }
+                if (e.which == 40) {
+                    $(select_id).prop('selectedIndex', Math.min(optionsCount - 1, current_id + 1));
+                }
+                if (e.which == 36) {
+                    $(select_id).prop('selectedIndex', 0);
+                }
+                if (e.which == 35) {
+                    $(select_id).prop('selectedIndex', optionsCount - 1);
+                }
+                $(select_id).trigger('change');
+                if (select_id.indexOf("CARD") == -1) {
+                    LoadSelect2Specify(select_id + '_CARD_1');
+                    LoadSelect2Specify(select_id + '_CARD_2');
+                    LoadSelect2Specify(select_id + '_CARD_3');
+                    LoadSelect2Specify(select_id + '_CARD_4');
+                }
+        }
+    });
+}
+
+// 指定された特定のオブジェクトをSELECT2に切替
+// 特定のアイテムを切り替えた時に呼ばれる
+function LoadSelect2Specify(select_id) {
+    $(select_id).select2();
+    // 同一スロットがカードとエンチャントに利用される場合があるので、スロットの状態によって検索機能をON/OFFする
+    var isEnchant = $(select_id + ' option:contains(エンチャントなし)').length > 0;
+    if (isEnchant) {
+        $(select_id).select2('destroy');
+    }
+    else if (select_id != '#OBJID_SELECT_JOB') {
+        CustomizeSelect2Specify(select_id);
+    }
+};
+
+// 指定された全てのオブジェクトをSELECT2に切替
+// 画面初期化時などに呼ばれる
 function LoadSelect2() {
     SEARCHABLE_SELECT_LIST.forEach((select_id) => {
-        $(select_id).select2();
-        // 同一スロットがカードとエンチャントに利用される場合があるので、スロットの状態によって検索機能をON/OFFする
-        var isEnchant = $(select_id + ' option:contains(エンチャントなし)').length > 0;
-        if (isEnchant) {
-            $(select_id).select2('destroy');
-        };
+        LoadSelect2Specify(select_id);
     });
 };
+
 // 以下のエレメントの状態が変化した時に select2 の UI を更新する
 // UI に異常がある場合はここで適切なエレメントが指定されているかチェックして下さい
 const INIT_TRIGGER_LIST = [
@@ -64,6 +113,8 @@ $(function(){
         LoadSelect2();
     })
 });
+
+// モンスター情報に Select2 を適用
 $(document).ready(function() {
     $('.OBJID_MONSTER_MAP_CATEGORY').select2();
     $('.OBJID_MONSTER_MAP_MAP').select2();


### PR DESCRIPTION
「旧らとりお仕様と同様」というリクエストに応えられるようにSelect2のイベントハンドラをカスタマイズする案です
複雑なことは基本避けたいですが一応問題なく動いたようなので #273 の比較対象としてPRしておきます

#265
