### PR TITLE
４次職のBaseLv自動調整機能が正しく動作するように改修

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -395,7 +395,7 @@
 											<tr>
 												<td style="min-width: 4em; text-align:center; background-color: #ddddff;">Pow</td>
 												<td style="min-width: 7em;">
-													<select id="OBJID_SELECT_STATUS_POW" name="A_POW" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_POW" name="A_POW" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_POW"></span>
 												</td>
 
@@ -413,7 +413,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Sta</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_STA" name="A_STA" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_STA" name="A_STA" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_STA"></span>
 												</td>
 
@@ -431,7 +431,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Wis</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_WIS" name="A_WIS" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_WIS" name="A_WIS" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_WIS"></span>
 												</td>
 
@@ -444,7 +444,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Spl</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_SPL" name="A_SPL" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_SPL" name="A_SPL" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_SPL"></span>
 												</td>
 
@@ -457,7 +457,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Con</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CON" name="A_CON" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_CON" name="A_CON" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CON"></span>
 												</td>
 
@@ -470,7 +470,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Crt</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CRT" name="A_CRT" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_CRT" name="A_CRT" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CRT"></span>
 												</td>
 											</tr>

--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -395,7 +395,7 @@
 											<tr>
 												<td style="min-width: 4em; text-align:center; background-color: #ddddff;">Pow</td>
 												<td style="min-width: 7em;">
-													<select id="OBJID_SELECT_STATUS_POW" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_POW" name="A_POW" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_POW"></span>
 												</td>
 
@@ -413,7 +413,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Sta</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_STA" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_STA" name="A_STA" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_STA"></span>
 												</td>
 
@@ -431,7 +431,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Wis</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_WIS" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_WIS" name="A_WIS" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_WIS"></span>
 												</td>
 
@@ -444,7 +444,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Spl</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_SPL" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_SPL" name="A_SPL" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_SPL"></span>
 												</td>
 
@@ -457,7 +457,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Con</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CON" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_CON" name="A_CON" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CON"></span>
 												</td>
 
@@ -470,7 +470,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Crt</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CRT" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
+													<select id="OBJID_SELECT_STATUS_CRT" name="A_CRT" onChange="CalcStatusPoint(false) | StAllCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CRT"></span>
 												</td>
 											</tr>

--- a/ro4/m/js/data/mig.job.h.js
+++ b/ro4/m/js/data/mig.job.h.js
@@ -409,6 +409,37 @@ function IsDoramJob(jobID) {
 }
 
 /**
+ * 対象の職業が４次職かを判定する.
+ * @return true: ４次職, false: ４次職ではない
+ */
+function IsYojiJob(jobID) {
+	switch (jobID) {
+		case MIG_JOB_ID_DRAGON_KNIGHT:
+		case MIG_JOB_ID_SHADOW_CROSS:
+		case MIG_JOB_ID_CARDINAL:
+		case MIG_JOB_ID_WIND_HAWK:
+		case MIG_JOB_ID_ARCH_MAGE:
+		case MIG_JOB_ID_MEISTER:
+		case MIG_JOB_ID_IMPERIAL_GUARD:
+		case MIG_JOB_ID_ABYSS_CHASER:
+		case MIG_JOB_ID_INQUISITOR:
+		case MIG_JOB_ID_TROUBADOUR:
+		case MIG_JOB_ID_TROUVERE:
+		case MIG_JOB_ID_ELEMENTAL_MASTER:
+		case MIG_JOB_ID_BIOLO:
+		case MIG_JOB_ID_SKY_EMPEROR:
+		case MIG_JOB_ID_SOUL_ASCETIC:
+		case MIG_JOB_ID_SHINKIROU:
+		case MIG_JOB_ID_SHIRANUI:
+		case MIG_JOB_ID_NIGHT_WATCH:
+		case MIG_JOB_ID_HYPER_NOVICE:
+		case MIG_JOB_ID_SPIRIT_HANDLER:
+			return true;
+	}
+	return false;
+}
+
+/**
  * 対象の職業が二刀流可能かを判定する.
  * @return true : 可能, false : 不可
  */


### PR DESCRIPTION
#283

以下のような処理を追加しました
・特性ステータスポイントの初期値を取得する
・特性ステータスの合計値を取得する
・４次職か否かを判定する
・特性ステータスの合計値が所持するポイントを超えている間は、その条件が崩れるまでBaseLvを上げる
・所持する特性ステータスポイントとBaseLvをレンダリングする

既存の処理を多少変更しているのでバグを埋め込んでいないか確認してからリリースする予定です