### PR TITLE
全ての項目について設定変更時の自動計算ON/OFFを実装

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -325,31 +325,31 @@
 
 											<tr>
 												<td style="min-width: 4em; text-align:center;">LV</td>
-												<td style="min-width: 7em;"><select id="OBJID_SELECT_BASE_LEVEL" name="A_BaseLV"onChange="CalcStatusPoint(true) | StAllCalc() | calc()"></select></td>
+												<td style="min-width: 7em;"><select id="OBJID_SELECT_BASE_LEVEL" name="A_BaseLV"onChange="CalcStatusPoint(true) | StAllCalc() | AutoCalc()"></select></td>
 
 												<td style="min-width: 4em; text-align:center;">JobLV</td>
-												<td style="min-width: 7em;"><select id="OBJID_SELECT_JOB_LEVEL" name="A_JobLV"onChange="StAllCalc() | calc()"></select></td>
+												<td style="min-width: 7em;"><select id="OBJID_SELECT_JOB_LEVEL" name="A_JobLV"onChange="StAllCalc() | AutoCalc()"></select></td>
 
 												<td style="min-width: 4em; text-align:center;">職業</td>
-												<td style="min-width: 7em;"><select id="OBJID_SELECT_JOB" name="A_JOB" onChange="OnChangeJobSelect(this.value) | StAllCalc() | CalcStatusPoint(false) | calc()"></select></td>
+												<td style="min-width: 7em;"><select id="OBJID_SELECT_JOB" name="A_JOB" onChange="OnChangeJobSelect(this.value) | StAllCalc() | CalcStatusPoint(false) | AutoCalc()"></select></td>
 											</tr>
 
 											<tr>
 												<td style="text-align: center;">Str</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_STR" name="A_STR" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_STR" name="A_STR" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_STR"></span>
 												</td>
 
 												<td style="text-align: center;">Agi</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_AGI" name="A_AGI" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_AGI" name="A_AGI" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_AGI"></span>
 												</td>
 
 												<td style="text-align: center;">Vit</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_VIT" name="A_VIT" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_VIT" name="A_VIT" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_VIT"></span>
 												</td>
 											</tr>
@@ -357,19 +357,19 @@
 											<tr>
 												<td style="text-align: center;">Int</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_INT" name="A_INT" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_INT" name="A_INT" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_INT"></span>
 												</td>
 
 												<td style="text-align: center;">Dex</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_DEX" name="A_DEX" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_DEX" name="A_DEX" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_DEX"></span>
 												</td>
 
 												<td style="text-align: center;">Luk</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_LUK" name="A_LUK" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_LUK" name="A_LUK" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_LUK"></span>
 												</td>
 											</tr>
@@ -395,7 +395,7 @@
 											<tr>
 												<td style="min-width: 4em; text-align:center; background-color: #ddddff;">Pow</td>
 												<td style="min-width: 7em;">
-													<select id="OBJID_SELECT_STATUS_POW" name="A_POW" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_POW" name="A_POW" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_POW"></span>
 												</td>
 
@@ -413,7 +413,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Sta</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_STA" name="A_STA" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_STA" name="A_STA" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_STA"></span>
 												</td>
 
@@ -431,7 +431,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Wis</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_WIS" name="A_WIS" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_WIS" name="A_WIS" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_WIS"></span>
 												</td>
 
@@ -444,7 +444,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Spl</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_SPL" name="A_SPL" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_SPL" name="A_SPL" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_SPL"></span>
 												</td>
 
@@ -457,7 +457,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Con</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CON" name="A_CON" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_CON" name="A_CON" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CON"></span>
 												</td>
 
@@ -470,7 +470,7 @@
 											<tr>
 												<td style="text-align:center; background-color: #ddddff;">Crt</td>
 												<td>
-													<select id="OBJID_SELECT_STATUS_CRT" name="A_CRT" onChange="CalcStatusPoint(false) | StAllCalc() | calc()"></select>
+													<select id="OBJID_SELECT_STATUS_CRT" name="A_CRT" onChange="CalcStatusPoint(false) | StAllCalc() | AutoCalc()"></select>
 													<span id="OBJID_SPAN_STATUS_BONUS_CRT"></span>
 												</td>
 											</tr>
@@ -648,13 +648,13 @@
 						<tr>
 							<td>
 								<span id="nm026">スピードポーション：</span>
-								<select id="OBJID_SPEED_POT" name = "A_SpeedPOT" onChange = "StAllCalc() | calc()">
+								<select id="OBJID_SPEED_POT" name = "A_SpeedPOT" onChange = "StAllCalc() | AutoCalc()">
 								</select>
 
 								<br>
 
 								<span id="nm027">武器タイプ：</span>
-								<select id="OBJID_ARMS_TYPE_RIGHT" name="A_WeaponType" onChange="OnChangeArmsTypeRight(this[this.selectedIndex].value) | StAllCalc() | calc()">
+								<select id="OBJID_ARMS_TYPE_RIGHT" name="A_WeaponType" onChange="OnChangeArmsTypeRight(this[this.selectedIndex].value) | StAllCalc() | AutoCalc()">
 								</select>
 
 								<span id = "A_SobWeaponName"></span>
@@ -677,7 +677,7 @@
 
 									<tr>
 										<td rowspan="2">
-											<select id="OBJID_ARMS_RIGHT_REFINE" name="A_Weapon_ATKplus" onChange = "OnChangeRefined() | calc()">
+											<select id="OBJID_ARMS_RIGHT_REFINE" name="A_Weapon_ATKplus" onChange = "OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -693,13 +693,13 @@
 										</td>
 
 										<td rowspan="2">
-											<select id="OBJID_ARMS_RIGHT" onChange="OnChangeEquip(EQUIP_REGION_ID_ARMS, parseInt(this.value)) | calc()">
+											<select id="OBJID_ARMS_RIGHT" onChange="OnChangeEquip(EQUIP_REGION_ID_ARMS, parseInt(this.value)) | AutoCalc()">
 											</select>
 										</td>
 
 										<td colspan="2">
 											<span id="ID_A_HUYO_NAME">武器属性付与</span>
-											<select id="OBJID_SELECT_ARMS_ELEMENT" name="A_Weapon_zokusei" onChange="calc()">
+											<select id="OBJID_SELECT_ARMS_ELEMENT" name="A_Weapon_zokusei" onChange="AutoCalc()">
 											</select>
 										</td>
 
@@ -718,7 +718,7 @@
 
 									<tr id="OBJID_ARMS_LEFT_SLOT_ROOT">
 										<td>
-											<select id="OBJID_ARMS_LEFT_REFINE" name="A_Weapon2_ATKplus" onChange = "OnChangeRefined() | calc()" disabled>
+											<select id="OBJID_ARMS_LEFT_REFINE" name="A_Weapon2_ATKplus" onChange = "OnChangeRefined() | AutoCalc()" disabled>
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -734,7 +734,7 @@
 										</td>
 
 										<td>
-											<select id="OBJID_ARMS_LEFT" onChange="OnChangeEquip(EQUIP_REGION_ID_ARMS_LEFT, parseInt(this.value)) | calc()">
+											<select id="OBJID_ARMS_LEFT" onChange="OnChangeEquip(EQUIP_REGION_ID_ARMS_LEFT, parseInt(this.value)) | AutoCalc()">
 											</select>
 										</td>
 
@@ -747,7 +747,7 @@
 
 									<tr id="OBJID_HEAD_TOP_SLOT_ROOT">
 										<td>
-											<select id="OBJID_HEAD_TOP_REFINE" name="A_HEAD_DEF_PLUS" onChange="OnChangeRefined() | calc()">
+											<select id="OBJID_HEAD_TOP_REFINE" name="A_HEAD_DEF_PLUS" onChange="OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -762,7 +762,7 @@
 											</select>
 										</td>
 										<td>
-											<select id="OBJID_HEAD_TOP" name="A_head1" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_TOP, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_HEAD_TOP" name="A_head1" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_TOP, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -778,7 +778,7 @@
 										</td>
 
 										<td>
-											<select id="OBJID_HEAD_MID" name="A_head2" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_MID, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_HEAD_MID" name="A_head2" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_MID, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -791,7 +791,7 @@
 										<td>
 										</td>
 										<td>
-											<select id="OBJID_HEAD_UNDER" name="A_head3" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_UNDER, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_HEAD_UNDER" name="A_head3" onChange="OnChangeEquip(EQUIP_REGION_ID_HEAD_UNDER, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -802,7 +802,7 @@
 
 									<tr id="OBJID_SHIELD_SLOT_ROOT">
 										<td id="ID_B4">
-											<select id="OBJID_SHIELD_REFINE" name="A_SHIELD_DEF_PLUS" onChange="OnChangeRefined() | calc()">
+											<select id="OBJID_SHIELD_REFINE" name="A_SHIELD_DEF_PLUS" onChange="OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -817,7 +817,7 @@
 											</select>
 										</td>
 										<td>
-											<select id="OBJID_SHIELD" name="A_left" onChange="OnChangeEquip(EQUIP_REGION_ID_SHIELD, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_SHIELD" name="A_left" onChange="OnChangeEquip(EQUIP_REGION_ID_SHIELD, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -828,7 +828,7 @@
 
 									<tr id="OBJID_BODY_SLOT_ROOT">
 										<td>
-											<select id="OBJID_BODY_REFINE" name="A_BODY_DEF_PLUS" onChange="OnChangeRefined() | calc()">
+											<select id="OBJID_BODY_REFINE" name="A_BODY_DEF_PLUS" onChange="OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -843,7 +843,7 @@
 											</select>
 										</td>
 										<td>
-											<select id="OBJID_BODY" name="A_body" onChange="OnChangeEquip(EQUIP_REGION_ID_BODY, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_BODY" name="A_body" onChange="OnChangeEquip(EQUIP_REGION_ID_BODY, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -854,7 +854,7 @@
 
 									<tr id="OBJID_SHOULDER_SLOT_ROOT">
 										<td>
-											<select id="OBJID_SHOULDER_REFINE" name="A_SHOULDER_DEF_PLUS" onChange="OnChangeRefined() | calc()">
+											<select id="OBJID_SHOULDER_REFINE" name="A_SHOULDER_DEF_PLUS" onChange="OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -869,7 +869,7 @@
 											</select>
 										</td>
 										<td>
-											<select id="OBJID_SHOULDER" name="A_shoulder" onChange="OnChangeEquip(EQUIP_REGION_ID_SHOULDER, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_SHOULDER" name="A_shoulder" onChange="OnChangeEquip(EQUIP_REGION_ID_SHOULDER, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -880,7 +880,7 @@
 
 									<tr id="OBJID_SHOES_SLOT_ROOT">
 										<td>
-											<select id="OBJID_SHOES_REFINE" name="A_SHOES_DEF_PLUS" onChange="OnChangeRefined() | calc()">
+											<select id="OBJID_SHOES_REFINE" name="A_SHOES_DEF_PLUS" onChange="OnChangeRefined() | AutoCalc()">
 												<option value="0">+0
 												<option value="1">+1
 												<option value="2">+2
@@ -895,7 +895,7 @@
 											</select>
 										</td>
 										<td>
-											<select id="OBJID_SHOES" name="A_shoes" onChange="OnChangeEquip(EQUIP_REGION_ID_SHOES, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_SHOES" name="A_shoes" onChange="OnChangeEquip(EQUIP_REGION_ID_SHOES, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -908,7 +908,7 @@
 										<td>
 										</td>
 										<td>
-											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -921,7 +921,7 @@
 										<td>
 										</td>
 										<td>
-											<select id="OBJID_ACCESSARY_2" name="A_acces2" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2, parseInt(this.value)) | calc()"></select>
+											<select id="OBJID_ACCESSARY_2" name="A_acces2" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2, parseInt(this.value)) | AutoCalc()"></select>
 										</td>
 									</tr>
 
@@ -954,8 +954,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -968,16 +968,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -990,8 +990,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1004,16 +1004,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1026,8 +1026,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1040,16 +1040,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1062,8 +1062,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1076,16 +1076,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1098,8 +1098,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1112,16 +1112,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1134,8 +1134,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1148,16 +1148,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1170,8 +1170,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1184,16 +1184,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1206,8 +1206,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1220,16 +1220,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1242,8 +1242,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1256,16 +1256,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1278,8 +1278,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1292,16 +1292,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1314,8 +1314,8 @@
 
 								<input type="checkbox" class="item-ctrl" checked>
 								<div class="item-conf">
-									<select class="item-refined" OnChange="calc()"></select>
-									<select class="item-select" OnChange="calc()"></select>
+									<select class="item-refined" OnChange="AutoCalc()"></select>
+									<select class="item-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<input type="checkbox" class="card-ctrl">
@@ -1328,16 +1328,16 @@
 
 								<input type="checkbox" class="rndopt-ctrl" checked>
 								<div class="rndopt-conf">
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
-									<select class="rndopt-kind-select" OnChange="calc()"></select>
-									<select class="rndopt-value-select" OnChange="calc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-kind-select" OnChange="AutoCalc()"></select>
+									<select class="rndopt-value-select" OnChange="AutoCalc()"></select>
 								</div>
 
 								<div class="divider-line"></div>
@@ -1424,7 +1424,7 @@
 						<div class="folding-block-body-MIG">
 							<div id="OBJID_ATTACK_SETTING_AUTO_CALC_MIG">
 								<input id="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC" type="checkbox" checked onchange="CAttackMethodAreaComponentManager.OnChangeAutoCalc()">
-								<label for="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC">攻撃方法変更時に自動で再計算する</label>
+								<label for="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC">設定変更時に自動で再計算する</label>
 							</div>
 							<div id="OBJID_ATTACK_SETTING_DIGIT3_MIG">
 								<input id="OBJID_CHECK_DIGIT3" type="checkbox" onchange="CAttackMethodAreaComponentManager.OnChangeDigit3()">

--- a/ro4/m/js/calcautospell.js
+++ b/ro4/m/js/calcautospell.js
@@ -1648,8 +1648,8 @@ function BuildUpSettingHtmlAutoSpell(objTbody) {
 function OnChangeSettingAutoSpell(bCalculate){
 
 	// 再計算フラグが指定されている場合は、再計算を行う
-	if (bCalculate) calc();
-
+	//if (bCalculate) calc();
+	if (bCalculate) AutoCalc();
 
 	// オートスペル設定が指定されているかをチェック
 	var bSet = false;

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -17212,10 +17212,14 @@ function Click_PassSkillSW(){
 
 
 
-
+/**
+ * パッシブ持続系の設定変更を反映する
+ * @param {*} n 再計算フラグ（1 = 再計算する, 1以外 = 再計算しない）
+ */
 function Click_A1(n){
 
-	if(n==1) calc();
+	//if(n==1) calc();
+	if(n==1) AutoCalc();
 
 	var sw=0;
 
@@ -17626,12 +17630,14 @@ function Skill3SW_2(){
 		}
 	}}
 
-
-
-
-
+/**
+ * 演奏/踊り系スキルの変更を反映する
+ * @param {*} n 再計算フラグ（n = 1 再計算する）
+ */
 function Click_A3(n){
-	if(n==1) calc();
+	//if(n==1) calc();
+	if(n==1) AutoCalc();
+	
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill3.length;i++){
 		if(n_A_PassSkill3[i] != 0){
@@ -17750,12 +17756,14 @@ function Click_Skill4SW(){
 		Click_A4(0);
 	}}
 
-
-
-
-
+/**
+ * ギルドスキル/ゴスペル/他の変更を反映する
+ * @param {*} n 再計算フラグ（n = 1 再計算する）
+ */
 function Click_A4(n){
-	if(n==1) calc();
+	//if(n==1) calc();
+	if(n==1) AutoCalc();
+	
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill4.length;i++) if(n_A_PassSkill4[i] != 0){
 		sw = 1;
@@ -18186,12 +18194,14 @@ function Click_Food_Off(){
 	}
 }
 
-
-
-
-
+/**
+ * アイテム(食品/他)の変更を反映する
+ * @param {*} n 再計算フラグ（n = 1 再計算する）
+ */
 function Click_A7(n){
-	if(n==1) calc();
+	//if(n==1) calc();
+	if(n==1) AutoCalc();
+	
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill7.length;i++) if(n_A_PassSkill7[i] != 0){
 		sw = 1;
@@ -18429,12 +18439,14 @@ function Click_Skill8SW(){
 	}
 }
 
-
-
-
-
+/**
+ * その他の支援/設定 (暫定追加機能)の変更を反映する
+ * @param {*} n 再計算フラグ（n = 1 再計算する）
+ */
 function Click_A8(n){
-	if(n==1) calc();
+	//if(n==1) calc();
+	if(n==1) AutoCalc();
+
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill8.length;i++) if(n_A_PassSkill8[i] != 0){
 		sw = 1;
@@ -19041,8 +19053,16 @@ function GetIkariPow(mobData) {
 	return pow;
 }
 
-
-
+/**
+ * 各種パラメータ変更時の自動計算機能
+ * 
+ */
+function AutoCalc() {
+	// 自動設定が有効の場合のみ、再計算する
+	if (HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked")) {
+		calc();
+	}
+}
 
 //================================================================================================================================
 //================================================================================================================================

--- a/roro/m/js/CConfBase.js
+++ b/roro/m/js/CConfBase.js
@@ -636,12 +636,10 @@ function CConfBase(confArray) {
 		}
 	}
 
-
-
-
-
 	/**
 	 * 設定欄の設定値変更イベントハンドラ.
+	 * @param {*} instanceNo 
+	 * @param {*} bCalc  再計算フラグ（true : 再計算する、false : 再計算しない）
 	 */
 	CConfBase.OnChangeValueHandler = function (instanceNo, bCalc) {
 
@@ -675,7 +673,8 @@ function CConfBase(confArray) {
 
 		// 再計算フラグが立っている場合は、再計算を実行
 		if (bCalc) {
-			calc();
+			//calc();
+			AutoCalc();
 		}
 	}
 

--- a/roro/m/js/CConfBase2.js
+++ b/roro/m/js/CConfBase2.js
@@ -1166,6 +1166,9 @@ function CConfBase2(confMngParam) {
 
 	/**
 	 * 設定欄の設定値変更イベントハンドラ.
+	 * @param {*} instanceNo 
+	 * @param {*} dataNo 
+	 * @param {*} bCalc true=再計算する, false=再計算しない
 	 */
 	CConfBase2.OnChangeValueHandler = function (instanceNo, dataNo, bCalc) {
 

--- a/roro/m/js/CTimeItemAreaComponentManager.js
+++ b/roro/m/js/CTimeItemAreaComponentManager.js
@@ -147,10 +147,11 @@ CTimeItemAreaComponentManager.OnClickExtractSwitch = function () {
 	CTimeItemAreaComponentManager.RebuildControls();
 };
 
-
-
 /**
- * 設定変更イベントハンドラ.
+ * アイテム時限効果の変更を反映する
+ * @param {*} idxConf 
+ * @param {*} dataId 
+ * @returns 
  */
 CTimeItemAreaComponentManager.OnChangeConf = function (idxConf, dataId) {
 
@@ -182,7 +183,8 @@ CTimeItemAreaComponentManager.OnChangeConf = function (idxConf, dataId) {
 	}
 
 	// 再計算
-	calc();
+	//calc();
+	AutoCalc();
 
 	// クイック調整欄の更新
 	CBattleQuickControlAreaComponentManager.RebuildControls();

--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -243,7 +243,7 @@ function OnChangeArmsTypeRight(itemKind){
 
 			objSelectArrow = document.createElement("select");
 			objSelectArrow.setAttribute("id", "OBJID_SELECT_ARROW");
-			objSelectArrow.setAttribute("onChange", "StAllCalc() | calc()");
+			objSelectArrow.setAttribute("onChange", "StAllCalc() | AutoCalc()");
 			objRoot.appendChild(objSelectArrow);
 		}
 
@@ -275,12 +275,12 @@ function OnChangeArmsTypeRight(itemKind){
 
 		if(GetHigherJobSeriesID(n_A_JOB) == 8 && itemKind != ITEM_KIND_KATAR){
 			if(n_Nitou == 0) {
-				myInnerHtml("A_SobWeaponName","　左手："+'<select id="OBJID_ARMS_TYPE_LEFT" name="A_Weapon2Type" onChange = "OnChangeArmsTypeLeft(this[this.selectedIndex].value) | StAllCalc() | calc()"> <option value="0">素手or盾<option value="1">短剣<option value="2">片手剣<option value="6">片手斧</select>',0);
+				myInnerHtml("A_SobWeaponName","　左手："+'<select id="OBJID_ARMS_TYPE_LEFT" name="A_Weapon2Type" onChange = "OnChangeArmsTypeLeft(this[this.selectedIndex].value) | StAllCalc() | AutoCalc()"> <option value="0">素手or盾<option value="1">短剣<option value="2">片手剣<option value="6">片手斧</select>',0);
 			}
 		}
 		else if((IsSameJobClass(JOB_ID_KAGERO) || IsSameJobClass(JOB_ID_OBORO)) && (itemKind != ITEM_KIND_FUMA)){
 			if(n_Nitou == 0) {
-				myInnerHtml("A_SobWeaponName","　左手："+'<select id="OBJID_ARMS_TYPE_LEFT" name="A_Weapon2Type" onChange = "OnChangeArmsTypeLeft(this[this.selectedIndex].value) | StAllCalc() | calc()"> <option value=0>素手or盾<option value=1>短剣</select>',0);
+				myInnerHtml("A_SobWeaponName","　左手："+'<select id="OBJID_ARMS_TYPE_LEFT" name="A_Weapon2Type" onChange = "OnChangeArmsTypeLeft(this[this.selectedIndex].value) | StAllCalc() | AutoCalc()"> <option value=0>素手or盾<option value=1>短剣</select>',0);
 			}
 		}
 		else{

--- a/roro/m/js/hmrndopt.js
+++ b/roro/m/js/hmrndopt.js
@@ -186,7 +186,7 @@ function CreateRndOptKind(objRoot, eqpRgnId, slotIndex) {
 
 	objSelect = HtmlCreateElement("select", objTd);
 	HtmlSetAttribute(objSelect, "id", objIdKind);
-	HtmlSetAttribute(objSelect, "onChange", "OnChangeRndOptKind(" + eqpRgnId + ", " + slotIndex + ") | calc()");
+	HtmlSetAttribute(objSelect, "onChange", "OnChangeRndOptKind(" + eqpRgnId + ", " + slotIndex + ") | AutoCalc()");
 
 	return objSelect;
 }
@@ -211,7 +211,7 @@ function CreateRndOptValue(objRoot, eqpRgnId, slotIndex) {
 
 	objSelect = HtmlCreateElement("select", objTd);
 	HtmlSetAttribute(objSelect, "id", objIdValue);
-	HtmlSetAttribute(objSelect, "onChange", "OnChangeRandomEnchant() | calc()");
+	HtmlSetAttribute(objSelect, "onChange", "OnChangeRandomEnchant() | AutoCalc()");
 
 	return objSelect;
 }

--- a/roro/m/js/mobconfbuf.js
+++ b/roro/m/js/mobconfbuf.js
@@ -816,7 +816,8 @@ function OnChangeMobConfBuf(bCalc) {
 
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
-		calc();
+		//calc();
+		AutoCalc();
 	}
 }
 

--- a/roro/m/js/mobconfdebuf.js
+++ b/roro/m/js/mobconfdebuf.js
@@ -1300,7 +1300,8 @@ function OnChangeMobConfDebuf(bCalc) {
 
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
-		calc();
+		//calc();
+		AutoCalc();
 	}
 }
 

--- a/roro/m/js/mobconfplayer.js
+++ b/roro/m/js/mobconfplayer.js
@@ -1254,7 +1254,8 @@ function OnChangeMobConfPlayer(bCalc) {
 
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
-		calc();
+		//calc();
+		AutoCalc();
 	}
 }
 

--- a/roro/m/js/slotpager.js
+++ b/roro/m/js/slotpager.js
@@ -531,7 +531,7 @@ function __RebuildSlotAsCard(eqpRgnId, objidPrifix) {
 		// カード選択セレクトボックス
 		objSelect = HtmlCreateElement("select", objTd);
 		HtmlSetAttribute(objSelect, "id", objidPrifix + "_CARD_" + idx);
-		HtmlSetAttribute(objSelect, "onChange", "OnChangeCard(this.value) | calc()");
+		HtmlSetAttribute(objSelect, "onChange", "OnChangeCard(this.value) | AutoCalc()");
 
 		// カード選択セレクトボックスの再構築
 		itemId = GetStatefullData("DATA_" + objidPrifix, 0);
@@ -589,7 +589,7 @@ function __RebuildSlotAsCardShort(eqpRgnId, objidPrifix) {
 	// カード選択セレクトボックス
 	objSelect = HtmlCreateElement("select", objTd);
 	HtmlSetAttribute(objSelect, "id", objidPrifix + "_CARD_SHORT");
-	HtmlSetAttribute(objSelect, "onChange", strOnChange + "| calc() | LoadSelect2()");
+	HtmlSetAttribute(objSelect, "onChange", strOnChange + "| AutoCalc() | LoadSelect2()");
 	if (bVisible) {
 		objSelect.removeAttribute("disabled");
 		objSelect.setAttribute("style", "visibility : visible");


### PR DESCRIPTION
#290 

- 基本ステータス
- 特性ステータス
- 武器＆防具/カード
- シャドウ装備
- パッシブ持続系
- 一次職支援設定
- 二次職支援設定
- 三次職支援設定
- 四次職支援設定
- モンスター状態異常設定
- モンスター状態強化設定
- 対プレイヤー設定
- 演奏/踊り系スキル
- ギルドスキル/ゴスペル/他
- オートスペル設定 (テスト中)
- アイテム(食品/他)
- アイテム時限効果
- その他の支援/設定 (暫定追加機能)
- 性能カスタマイズ（ステータス関連）
- 性能カスタマイズ（攻撃関連）
- 性能カスタマイズ（防御関連）
- 性能カスタマイズ（特性ステータス関連）
- 性能カスタマイズ（スキル関連）