### PR TITLE
自動計算機能の改善

### DIFF
--- a/ro4/m/calcx.css
+++ b/ro4/m/calcx.css
@@ -178,11 +178,11 @@ body[class="CLS_BODY_ALTERNATIVE"] .folding-block-body-MIG {
 	margin-left: 1em;
 }
 
-#OBJID_ATTACK_SETTING_AUTO_CALC_MIG {
+#OBJID_ATTACK_SETTING_DIGIT3_MIG {
 	grid-row: 1;
 	grid-column: 1;
 }
-#OBJID_ATTACK_SETTING_DIGIT3_MIG {
+#OBJID_ATTACK_SETTING_AUTO_CALC_MIG {
 	grid-row: 2;
 	grid-column: 1;
 }

--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -1425,13 +1425,18 @@
 						<label for="OBJID_SWITCH_ATTACK_SETTING_MIG">動作設定</label>
 						<span class="folding-link-help-MIG"><a href="../other/set.html" target="_blank">説明表示</a></span>
 						<div class="folding-block-body-MIG">
-							<div id="OBJID_ATTACK_SETTING_AUTO_CALC_MIG">
-								<input id="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC" type="checkbox" checked onchange="CAttackMethodAreaComponentManager.OnChangeAutoCalc()">
-								<label for="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC">設定変更時に自動で再計算する</label>
-							</div>
 							<div id="OBJID_ATTACK_SETTING_DIGIT3_MIG">
 								<input id="OBJID_CHECK_DIGIT3" type="checkbox" onchange="CAttackMethodAreaComponentManager.OnChangeDigit3()">
 								<label for="OBJID_CHECK_DIGIT3">3桁区切りで表示する</label>
+							</div>
+							<div id="OBJID_ATTACK_SETTING_AUTO_CALC_MIG">
+								<label for="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC">自動再計算：</label>
+								<select id="OBJID_INPUT_ATTACK_METHOD_AUTO_CALC" onchange="CAttackMethodAreaComponentManager.OnChangeAutoCalc()">
+									<option value="0">攻撃方法変更時に自動で再計算しない</option>
+									<option value="1">攻撃方法変更時に自動で再計算する</option>
+									<option value="2">全ての項目変更時に自動で再計算しない</option>
+									<option value="3">全ての項目変更時に自動で再計算する</option>
+								</select>
 							</div>
 							<div id="OBJID_ATTACK_SETTING_ACTIVE_INTERVAL_MIG">
 								<label for="OBJID_SELECT_ACTIVE_INTERVAL">アクティブスキルの限界攻撃間隔：</label>

--- a/ro4/m/js/CAttackMethodAreaComponentManager.js
+++ b/ro4/m/js/CAttackMethodAreaComponentManager.js
@@ -423,7 +423,7 @@ CAttackMethodAreaComponentManager.RebuildControls = function () {
 
 
 	// 自動計算フラグを保持しておく
-	checkedAutoCalc = HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked");
+	checkedAutoCalc = HtmlGetObjectValueByIdAsInteger("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", 0);
 
 
 	// 設定欄を初期化
@@ -1028,11 +1028,11 @@ CAttackMethodAreaComponentManager.RebuildAttackMethodSelectSubOptionSubCreate = 
  */
 CAttackMethodAreaComponentManager.RebuildSettingArea = function () {
 
-	let bAutoCalc = CSaveController.getSettingProp(CSaveDataConst.propNameAttackAutoCalc);
-	HtmlSetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", bAutoCalc ? "checked" : null);
-
 	let bDigit3 = CSaveController.getSettingProp(CSaveDataConst.propNameResultDigit3);
 	HtmlSetObjectCheckedById("OBJID_CHECK_DIGIT3", bDigit3 ? "checked" : null);
+
+	let autoCalc = CSaveController.getSettingProp(CSaveDataConst.propNameAttackAutoCalc);
+	HtmlSetObjectValueById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", autoCalc);
 
 	let attackInterval = CSaveController.getSettingProp(CSaveDataConst.propNameAttackInterval);
 	HtmlSetObjectValueById("OBJID_SELECT_ACTIVE_INTERVAL", attackInterval);
@@ -1055,16 +1055,12 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethod = function () {
 	var attackMethodData = null;
 	var attackMethodOptList = null;
 
-
-
 	// 選択状態を取得し、設定変更により無効になった部分を切り捨てる
 	selectedValueArray = CAttackMethodAreaComponentManager.GetSelectedValueArray();
 	selectedValueArray.splice(1);
 
 	// 選択された攻撃手段データを取得する
 	attackMethodData = CAttackMethodAreaComponentManager.GetAttackMethodData(selectedValueArray[0]);
-
-
 
 	// 攻撃手段オプション選択部品の再構築
 
@@ -1074,17 +1070,11 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethod = function () {
 	// 攻撃手段オプション選択部品の再構築（再起処理される）
 	CAttackMethodAreaComponentManager.RebuildAttackMethodSelectSubOption(1, attackMethodOptList, selectedValueArray);
 
-
-
 	// 選択部品のリフレッシュ
 	CAttackMethodAreaComponentManager.RefreshControls();
 
-
-
 	// 自動設定が有効の場合のみ、再計算する
-	if (HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked")) {
-		calc();
-	}
+	AutoCalc("CAttackMethodAreaComponentManager.OnChangeAttackMethod");
 };
 
 
@@ -1101,8 +1091,6 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethodOption = function (objectI
 	var attackMethodData = null;
 	var attackMethodOptList = null;
 
-
-
 	// 選択状態を取得し、設定変更により無効になった部分を切り捨てる
 	selectedValueArray = CAttackMethodAreaComponentManager.GetSelectedValueArray();
 	// TODO: 要検討項目
@@ -1112,8 +1100,6 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethodOption = function (objectI
 
 	// 選択された攻撃手段データを取得する
 	attackMethodData = CAttackMethodAreaComponentManager.GetAttackMethodData(selectedValueArray[0]);
-
-
 
 	// 攻撃手段オプション選択部品の再構築
 
@@ -1136,7 +1122,6 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethodOption = function (objectI
 			break;
 		}
 
-
 		// 存在しないところまで達した場合は、処理打ち切り
 		if (!attackMethodOptList) {
 			break;
@@ -1146,17 +1131,11 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethodOption = function (objectI
 	// 処理関数呼び出し（再帰処理される）
 	CAttackMethodAreaComponentManager.RebuildAttackMethodSelectSubOption(objectIndex + 1, attackMethodOptList, selectedValueArray);
 
-
-
 	// 選択部品のリフレッシュ
 	CAttackMethodAreaComponentManager.RefreshControls();
 
-
-
 	// 自動設定が有効の場合のみ、再計算する
-	if (HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked")) {
-		calc();
-	}
+	AutoCalc("CAttackMethodAreaComponentManager.OnChangeAttackMethodOption");
 };
 
 
@@ -1167,15 +1146,13 @@ CAttackMethodAreaComponentManager.OnChangeAttackMethodOption = function (objectI
 CAttackMethodAreaComponentManager.OnChangeAutoCalc = function () {
 
 	// 設定値取得
-	const checked = HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked");
+	const value = HtmlGetObjectValueByIdAsInteger("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", 0);
 
 	// セーブコントローラへ保存
-	CSaveController.setSettingProp(CSaveDataConst.propNameAttackAutoCalc, (checked ? 1 : 0));
+	CSaveController.setSettingProp(CSaveDataConst.propNameAttackAutoCalc, value);
 
 	// 自動計算が有効の場合のみ、再計算する
-	if (checked) {
-		calc();
-	}
+	AutoCalc("CAttackMethodAreaComponentManager.OnChangeAutoCalc");
 };
 
 /**

--- a/ro4/m/js/CSaveController.js
+++ b/ro4/m/js/CSaveController.js
@@ -392,6 +392,7 @@ class CSaveController {
 
 		const rrtstAll = localStorage.getItem(CSaveController.STORAGE_NAME_SETTINGS);
 
+		// ローカルストレージが空の場合は初期化する
 		if (!rrtstAll) {
 			this.#settingDataUnit = new (CSaveDataUnitTypeManager.getUnitClass(SAVE_DATA_UNIT_TYPE_SETTINGS))();
 			this.#settingDataUnit.SetUpAsDefault();
@@ -403,7 +404,17 @@ class CSaveController {
 
 		// パース
 		const parser = new CSaveDataUnitParse();
-		parser.parse(rrtst, 0);
+
+		// バージョン補完
+		if (rrtst.length < 7) {
+			// 旧バージョン
+			parser.parse(rrtst + "0", 0);	// 仮プロパティ0を付与して取り敢えず読み込む
+			parser.saveDataUnitArray[0].parsedMap.set("attackAutoCalc", parser.saveDataUnitArray[0].parsedMap.get("attackAutoCalc_old_1"));	// 旧プロパティを新プロパティに移植する
+		} else {
+			// 最新バージョン
+			parser.parse(rrtst, 0);
+		}
+
 		this.#settingDataUnit = parser.saveDataUnitArray[0];
 	}
 

--- a/ro4/m/js/CSaveDataUnit.js
+++ b/ro4/m/js/CSaveDataUnit.js
@@ -2060,6 +2060,7 @@ class CSaveDataConst {
 	/**
 	 * プロパティ名：攻撃方法変更時自動計算.
 	 */
+	static propNameAttackAutoCalc_old1 = "attackAutoCalc_old_1";
 	static propNameAttackAutoCalc = "attackAutoCalc";
 
 	/**
@@ -6040,10 +6041,11 @@ const SAVE_DATA_UNIT_TYPE_SETTINGS = CSaveDataUnitTypeManager.register(
 		 */
 		static get #propNamesSelf () {
 			return [
-				CSaveDataConst.propNameAttackAutoCalc,
+				CSaveDataConst.propNameAttackAutoCalc_old1,	// ver 1 旧プロパティ 
 				CSaveDataConst.propNameResultDigit3,
 				CSaveDataConst.propNameAttackInterval,
 				CSaveDataConst.propNameCastSimInterval,
+				CSaveDataConst.propNameAttackAutoCalc,
 			];
 		}
 
@@ -6064,11 +6066,11 @@ const SAVE_DATA_UNIT_TYPE_SETTINGS = CSaveDataUnitTypeManager.register(
 
 			// プロパティ定義情報の登録
 			this.registerPropInfo(CSaveDataConst.propNameParseCtrlFlag, 4);
-
-			this.registerPropInfo(CSaveDataConst.propNameAttackAutoCalc, 1);
+			this.registerPropInfo(CSaveDataConst.propNameAttackAutoCalc_old1, 1);	// ver 1 旧プロパティ 
 			this.registerPropInfo(CSaveDataConst.propNameResultDigit3, 1);
 			this.registerPropInfo(CSaveDataConst.propNameAttackInterval, 6);
 			this.registerPropInfo(CSaveDataConst.propNameCastSimInterval, 8);
+			this.registerPropInfo(CSaveDataConst.propNameAttackAutoCalc, 8);	// 4項目(2bit)で足りるが文字列表現の長さがちょうど1増える8bitを確保
 		}
 
 
@@ -6079,11 +6081,11 @@ const SAVE_DATA_UNIT_TYPE_SETTINGS = CSaveDataUnitTypeManager.register(
 		 */
 		SetUpAsDefault() {
 			super.SetUpAsDefault();
-
-			this.setProp(CSaveDataConst.propNameAttackAutoCalc, 1);
+			this.setProp(CSaveDataConst.propNameAttackAutoCalc_old1, 1);	// ver 1 旧プロパティ 
 			this.setProp(CSaveDataConst.propNameResultDigit3, 0);
 			this.setProp(CSaveDataConst.propNameAttackInterval, 14);
 			this.setProp(CSaveDataConst.propNameCastSimInterval, 10);
+			this.setProp(CSaveDataConst.propNameAttackAutoCalc, 0);
 		}
 
 		/**

--- a/ro4/m/js/calcautospell.js
+++ b/ro4/m/js/calcautospell.js
@@ -1515,7 +1515,7 @@ function BuildUpSettingHtmlAutoSpell(objTbody) {
 		objSelect = document.createElement("select");
 		objTd.appendChild(objSelect);
 		objSelect.setAttribute("id", "OBJID_AS_SKILL_ID_" + (OBJID_OFFSET_AS_SKILL_ID + idx));
-		objSelect.setAttribute("onChange", "OnChangeSettingAutoSpell(true)");
+		objSelect.setAttribute("onChange", "StAllCalc() | OnChangeSettingAutoSpell(true)");
 
 		//----------------------------------------------------------------
 		// オートスペルをソートする
@@ -1599,7 +1599,7 @@ function BuildUpSettingHtmlAutoSpell(objTbody) {
 		objSelect = document.createElement("select");
 		objTd.appendChild(objSelect);
 		objSelect.setAttribute("id", "OBJID_AS_SKILL_LV_" + (OBJID_OFFSET_AS_SKILL_LV + idx));
-		objSelect.setAttribute("onChange", "OnChangeSettingAutoSpell(true)");
+		objSelect.setAttribute("onChange", "StAllCalc() | OnChangeSettingAutoSpell(true)");
 
 		// Lv-, 1, 2, ... , 10 を設定
 		for (var lvidx = 0; lvidx <= 10; lvidx++) {
@@ -1619,7 +1619,7 @@ function BuildUpSettingHtmlAutoSpell(objTbody) {
 		objSelect = document.createElement("select");
 		objTd.appendChild(objSelect);
 		objSelect.setAttribute("id", "OBJID_AS_SKILL_PROB_" + (OBJID_OFFSET_AS_SKILL_PROB + idx));
-		objSelect.setAttribute("onChange", "OnChangeSettingAutoSpell(true)");
+		objSelect.setAttribute("onChange", "StAllCalc() | OnChangeSettingAutoSpell(true)");
 
 		for (var probidx = 0; probidx < AUTO_SPELL_PROB_ARRAY.length; probidx++) {
 			optionText = (AUTO_SPELL_PROB_ARRAY[probidx] / 10) + "%";

--- a/ro4/m/js/calcautospell.js
+++ b/ro4/m/js/calcautospell.js
@@ -1648,8 +1648,7 @@ function BuildUpSettingHtmlAutoSpell(objTbody) {
 function OnChangeSettingAutoSpell(bCalculate){
 
 	// 再計算フラグが指定されている場合は、再計算を行う
-	//if (bCalculate) calc();
-	if (bCalculate) AutoCalc();
+	if (bCalculate) AutoCalc("OnChangeSettingAutoSpell");
 
 	// オートスペル設定が指定されているかをチェック
 	var bSet = false;

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -17339,9 +17339,11 @@ function Click_A1(n){
 
 	var end = passiveSkillIdArray.length;
 
-	for(var i=0;i <end;i++) if(n_A_PassSkill[i] != 0){
-		sw = 1;
-		break;
+	for(var i=0;i <end;i++){
+		if(n_A_PassSkill[i] != 0){
+			sw = 1;
+			break;
+		}
 	}
 	if(sw == 0){
 		document.getElementById('A1TD').style.backgroundColor = "#DDDDFF";
@@ -17487,7 +17489,9 @@ function Click_Skill3SW(){
 
 
 
-
+/**
+ * 演奏/踊り系スキルの変更を変数に反映する
+ */
 function Skill3SW_2(){
 	with(document.calcForm){
 		n_A_PassSkill3[0] = eval(A3_Skill0_1.value);
@@ -17770,7 +17774,9 @@ function Click_A3(n){
 
 
 
-
+/**
+ * ギルドスキル/ゴスペル/他　を構築する
+ */
 function Click_Skill4SW(){
 	with(document.calcForm){
 		n_Skill4SW = A4_SKILLSW.checked;
@@ -17793,18 +17799,18 @@ function Click_Skill4SW(){
 			name_CS4SW_SKILL = ["臨戦体勢","偉大なる指導力","栄光の傷","冷静な心","鋭い視線","ステータスALL+20","HP+100%","SP+100%","ATK+100%","HIT+50＆FLEE+50","被ダメージ半減"];
 			html_CS4SW_SKILL = new Array();
 			for(i=0;i<=10;i++) myInnerHtml("EN4"+i+"_1",name_CS4SW_SKILL[i],0);
-			html_CS4SW_SKILL[0] = '<input type="checkbox" name="A4_Skill0"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[1] = '<select name="A4_Skill1"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[2] = '<select name="A4_Skill2"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[3] = '<select name="A4_Skill3"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[4] = '<select name="A4_Skill4"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[5] = '<input type="checkbox" name="A4_Skill5"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[6] = '<input type="checkbox" name="A4_Skill6"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[7] = '<input type="checkbox" name="A4_Skill7"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[8] = '<input type="checkbox" name="A4_Skill8"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[9] = '<input type="checkbox" name="A4_Skill9"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[10] = '<input type="checkbox" name="A4_Skill10"onClick="Click_A4(1)">';
-			html_CS4SW_SKILL[11] = '<select name="A4_Skill11"onChange="Click_A4(1)"></select>';
+			html_CS4SW_SKILL[0] = '<input type="checkbox" name="A4_Skill0"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[1] = '<select name="A4_Skill1"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[2] = '<select name="A4_Skill2"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[3] = '<select name="A4_Skill3"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[4] = '<select name="A4_Skill4"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[5] = '<input type="checkbox" name="A4_Skill5"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[6] = '<input type="checkbox" name="A4_Skill6"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[7] = '<input type="checkbox" name="A4_Skill7"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[8] = '<input type="checkbox" name="A4_Skill8"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[9] = '<input type="checkbox" name="A4_Skill9"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[10] = '<input type="checkbox" name="A4_Skill10"onClick="StAllCalc() | Click_A4(1)">';
+			html_CS4SW_SKILL[11] = '<select name="A4_Skill11"onChange="StAllCalc() | Click_A4(1)"></select>';
 			for(i=0;i<=11;i++) myInnerHtml("EN4"+i+"_2",html_CS4SW_SKILL[i],0);
 			myInnerHtml("EN430_1","STR",0);
 			myInnerHtml("EN431_1","AGI",0);
@@ -17812,12 +17818,12 @@ function Click_Skill4SW(){
 			myInnerHtml("EN433_1","INT",0);
 			myInnerHtml("EN434_1","DEX",0);
 			myInnerHtml("EN435_1","LUK",0);
-			html_CS4SW_SKILL[30] = '<select name="A4_Skill30"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[31] = '<select name="A4_Skill31"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[32] = '<select name="A4_Skill32"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[33] = '<select name="A4_Skill33"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[34] = '<select name="A4_Skill34"onChange="Click_A4(1)"></select>';
-			html_CS4SW_SKILL[35] = '<select name="A4_Skill35"onChange="Click_A4(1)"></select>';
+			html_CS4SW_SKILL[30] = '<select name="A4_Skill30"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[31] = '<select name="A4_Skill31"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[32] = '<select name="A4_Skill32"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[33] = '<select name="A4_Skill33"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[34] = '<select name="A4_Skill34"onChange="StAllCalc() | Click_A4(1)"></select>';
+			html_CS4SW_SKILL[35] = '<select name="A4_Skill35"onChange="StAllCalc() | Click_A4(1)"></select>';
 			for(i=30;i<=35;i++) myInnerHtml("EN4"+i+"_2",html_CS4SW_SKILL[i],0);
 			for(i=0;i<=5;i++){
 				A4_Skill1.options[i] = new Option(i,i);
@@ -17875,9 +17881,11 @@ function Click_A4(n){
 	if(n==1) AutoCalc("Click_A4");
 
 	var sw=0;
-	for(var i=0;i <n_A_PassSkill4.length;i++) if(n_A_PassSkill4[i] != 0){
-		sw = 1;
-		break;
+	for(var i=0;i <n_A_PassSkill4.length;i++) {
+		if(n_A_PassSkill4[i] != 0){
+			sw = 1;
+			break;
+		}
 	}
 	if(sw == 0){
 		document.getElementById('A4TD').style.backgroundColor = "#DDDDFF";
@@ -18056,7 +18064,7 @@ function Click_Skill7SW(){
 
 				objSelect = HtmlCreateElement("select", objTd);
 				objSelect.setAttribute("name", "A7_Skill" + subInfoArray[idxKind][0]);
-				objSelect.setAttribute("onchange", "Click_A7(1)");
+				objSelect.setAttribute("onchange", "StAllCalc() | Click_A7(1)");
 
 				HtmlCreateElementOption(0, subInfoArray[idxKind][1] + "+食品", objSelect);
 				for (idxValue = 1; idxValue <= 10; idxValue++) {
@@ -18072,7 +18080,7 @@ function Click_Skill7SW(){
 			objInput.setAttribute("type", "button");
 			objInput.setAttribute("id", "FOODOFF");
 			objInput.setAttribute("value", "全解除");
-			objInput.setAttribute("onclick", "Click_Food_Off()");
+			objInput.setAttribute("onclick", "Click_Food_Off() | StAllCalc()");
 
 			HtmlCreateTextNode(" ", objTd);
 
@@ -18080,7 +18088,7 @@ function Click_Skill7SW(){
 			objInput.setAttribute("type", "button");
 			objInput.setAttribute("name", "NETCAFE3");
 			objInput.setAttribute("value", "ALL＋10");
-			objInput.setAttribute("onclick", "Click_NetCafe3()");
+			objInput.setAttribute("onclick", "Click_NetCafe3() | StAllCalc()");
 
 			HtmlCreateElement("br", objTd);
 
@@ -18098,7 +18106,7 @@ function Click_Skill7SW(){
 			objInput.setAttribute("type", "checkbox");
 			objInput.setAttribute("id", "OBJID_CHECK_A7_Skill15");
 			objInput.setAttribute("name", "A7_Skill15");
-			objInput.setAttribute("onclick", "Click_A7(1)|CAttackMethodAreaComponentManager.RebuildControls()");
+			objInput.setAttribute("onclick", "StAllCalc() | Click_A7(1) | CAttackMethodAreaComponentManager.RebuildControls()");
 
 			objLabel = HtmlCreateElement("label", objTd);
 			objLabel.setAttribute("for", "OBJID_CHECK_A7_Skill15");
@@ -18129,7 +18137,7 @@ function Click_Skill7SW(){
 				objInput.setAttribute("type", "checkbox");
 				objInput.setAttribute("id", "OBJID_CHECK_A7_Skill" + subInfoArray[idxKind][0]);
 				objInput.setAttribute("name", "A7_Skill" + subInfoArray[idxKind][0]);
-				objInput.setAttribute("onclick", "Click_A7(1)");
+				objInput.setAttribute("onclick", "StAllCalc() | Click_A7(1)");
 
 				objLabel = HtmlCreateElement("label", objTd);
 				objLabel.setAttribute("for", "OBJID_CHECK_A7_Skill" + subInfoArray[idxKind][0]);
@@ -18165,7 +18173,7 @@ function Click_Skill7SW(){
 				objInput.setAttribute("type", "checkbox");
 				objInput.setAttribute("id", "OBJID_CHECK_A7_Skill" + buildInfo[0]);
 				objInput.setAttribute("name", "A7_Skill" + buildInfo[0]);
-				objInput.setAttribute("onclick", "Click_A7(1)");
+				objInput.setAttribute("onclick", "StAllCalc() | Click_A7(1)");
 
 				objLabel = HtmlCreateElement("label", objTd);
 				objLabel.setAttribute("for", "OBJID_CHECK_A7_Skill" + buildInfo[0]);
@@ -18185,7 +18193,7 @@ function Click_Skill7SW(){
 
 				objSelect = HtmlCreateElement("select", objTd);
 				objSelect.setAttribute("name", "A7_Skill" + buildInfo[0]);
-				objSelect.setAttribute("onchange", "Click_A7(1)");
+				objSelect.setAttribute("onchange", "StAllCalc() | Click_A7(1)");
 
 				for (idxValue = 0; idxValue < buildInfo[2].length; idxValue++) {
 					HtmlCreateElementOption(idxValue, buildInfo[2][idxValue], objSelect);
@@ -18209,7 +18217,7 @@ function Click_Skill7SW(){
 
 		objSelect = HtmlCreateElement("select", objTd);
 		objSelect.setAttribute("name", "A7_Skill" + subInfoArray[idxKind][0]);
-		objSelect.setAttribute("onchange", "Click_A7(1)");
+		objSelect.setAttribute("onchange", "StAllCalc() | Click_A7(1)");
 
 		HtmlCreateElementOption(0, "期間限定系[" + subInfoArray[idxKind][1] + "] なし", objSelect);
 		for (idxValue = 1; idxValue <= 50; idxValue++) {
@@ -18312,9 +18320,11 @@ function Click_A7(n){
 	if(n==1) AutoCalc("Click_A7");
 
 	var sw=0;
-	for(var i=0;i <n_A_PassSkill7.length;i++) if(n_A_PassSkill7[i] != 0){
-		sw = 1;
-		break;
+	for(var i=0;i <n_A_PassSkill7.length;i++){
+		if(n_A_PassSkill7[i] != 0){
+			sw = 1;
+			break;
+		}
 	}
 	if(sw == 0){
 		document.getElementById('A7TD').style.backgroundColor = "#DDDDFF";
@@ -18380,7 +18390,7 @@ function Click_Skill8SW(){
 		if(n_Skill8SW){
 			var str;
 			str = '<TABLE Border><TR><TD id="A8TD" Colspan="2" class="title"><input id="OBJID_CHECK_A8_SKILLSW" type="checkbox" name="A8_SKILLSW"onClick="Click_Skill8SW()"><label for="OBJID_CHECK_A8_SKILLSW">その他の支援/設定 (暫定追加機能)</label><SPAN id="A8used"></SPAN></TD></TR>';
-			str += '<TR><TD>ペット：<select id="OBJID_SELECT_PET" name="A8_Skill0" onchange="OnChangePetSelect()"></select></TD><TD>親密度：<select id="OBJID_SELECT_PET_FRIENDLITY" name="A8_Skill17" onChange="Click_A8(1)"></select></TD></TR>';
+			str += '<TR><TD>ペット：<select id="OBJID_SELECT_PET" name="A8_Skill0" onchange="StAllCalc() | OnChangePetSelect()"></select></TD><TD>親密度：<select id="OBJID_SELECT_PET_FRIENDLITY" name="A8_Skill17" onChange="StAllCalc() | Click_A8(1)"></select></TD></TR>';
 			str += '<TR><TD colspan="2"><SPAN id="OBJID_SPAN_PET_EXPLAIN"></SPAN></TD></TR>';
 			str += '<TR><TD id="EN801"></TD><TD id="EN802"></TD></TR>';
 			str += '<TR><TD id="EN803"></TD><TD id="EN804"></TD></TR>';
@@ -18432,82 +18442,82 @@ function Click_Skill8SW(){
 
 
 
-			myInnerHtml("EN801",'戦闘教範系<select name="A8_Skill1" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN801",'戦闘教範系<select name="A8_Skill1" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			var w_name=["なし","25","50","75","100","(125)","(150)"];
 			for(i=0;i<=6;i++) A8_Skill1.options[i] = new Option(w_name[i],i);
-			myInnerHtml("EN802",'Job教範系<select name="A8_Skill2" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN802",'Job教範系<select name="A8_Skill2" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			var w_name=["なし","50","(75)","(100)"];
 			for(i=0;i<=3;i++) A8_Skill2.options[i] = new Option(w_name[i],i);
-			myInnerHtml("EN803",'ネットカフェ経験値UP<select name="A8_Skill3" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN803",'ネットカフェ経験値UP<select name="A8_Skill3" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill3.options[0] = new Option("-",0);
 			for(i=1;i<=2;i++){
 				var wy = 50 * i;
 				var wx = (100 + wy) / 100;
 				A8_Skill3.options[i] = new Option("+"+ wy +"%("+ wx +"倍)",i);
 			}
-			myInnerHtml("EN804",'経験値増加キャンペーン<select name="A8_Skill7" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN804",'経験値増加キャンペーン<select name="A8_Skill7" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill7.options[0] = new Option("-",0);
 			for(i=1;i<=8;i++){
 				var wy = 25 * i;
 				var wx = (100 + wy) / 100;
 				A8_Skill7.options[i] = new Option(wx+"倍(+"+(25*i)+"%)",i);
 			}
-			myInnerHtml("EN822",'OTP<select name="A8_Skill22" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN822",'OTP<select name="A8_Skill22" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill22.options[0] = new Option("ログインボーナスなし",0);
 			A8_Skill22.options[1] = new Option("ブロンズ(Exp+5%)",1);
 			A8_Skill22.options[2] = new Option("シルバー(↑＋スピードポーション)",2);
 			A8_Skill22.options[3] = new Option("ゴールド(↑＋Hit+10/Flee+10)",3);
 			A8_Skill22.options[4] = new Option("レインボー(↑＋MaxHP+20%/MaxSP+20%)",4);
 			myInnerHtml("EN823",'←ジョンダパスはOTPレインボーです',0);
-			myInnerHtml("EN805",'公平PT人数<select name="A8_Skill5" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN805",'公平PT人数<select name="A8_Skill5" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill5.options[0] = new Option("-",0);
 			for(i=1;i<=11;i++) A8_Skill5.options[i] = new Option((i+1)+"人",i);
-			myInnerHtml("EN806",'共闘ボーナス<select name="A8_Skill6" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN806",'共闘ボーナス<select name="A8_Skill6" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill6.options[0] = new Option("-",0);
 			for(i=1;i<=20;i++) A8_Skill6.options[i] = new Option("+"+ (i*25) +"%",i);
-			myInnerHtml("EN821",'討伐クエストのExpを加算(1匹あたりの値)<select name="A8_Skill21" disabled="disabled" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN821",'討伐クエストのExpを加算(1匹あたりの値)<select name="A8_Skill21" disabled="disabled" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A8_Skill21.options[0] = new Option("-",0);
 			A8_Skill21.options[1] = new Option("BaseExpで受け取る",1);
 			A8_Skill21.options[2] = new Option("JobExpで受け取る",2);
-			myInnerHtml("EN807",'<input id="OBJID_CHECK_A8_Skill4" type="checkbox" name="A8_Skill4"onClick="Click_A8(1)"><label for="OBJID_CHECK_A8_Skill4">結婚スパノビステータスALL+1付与</label>',0);
-			myInnerHtml("EN808",'<input id="OBJID_CHECK_A8_Skill13" type="checkbox" name="A8_Skill13"onClick="Click_A8(1)||RebuildStatusSelect()||CalcStatusPoint(true)"><label for="OBJID_CHECK_A8_Skill13">養子状態にする</label>',0);
+			myInnerHtml("EN807",'<input id="OBJID_CHECK_A8_Skill4" type="checkbox" name="A8_Skill4"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A8_Skill4">結婚スパノビステータスALL+1付与</label>',0);
+			myInnerHtml("EN808",'<input id="OBJID_CHECK_A8_Skill13" type="checkbox" name="A8_Skill13"onClick="StAllCalc() | Click_A8(1)||RebuildStatusSelect()||CalcStatusPoint(true)"><label for="OBJID_CHECK_A8_Skill13">養子状態にする</label>',0);
 
 			myInnerHtml("EN809",'<font size="2" color="red">（時限性補助効果の設定は、「アイテム時限効果」設定欄へ移動しました）</font><input type="button" value="設定欄を表示" onclick="CTimeItemAreaComponentManager.FocusArea(0, true)">',0);
 
-			myInnerHtml("EN810",'囲んでいる敵の数<select name="A8_Skill12" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN810",'囲んでいる敵の数<select name="A8_Skill12" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			for(i=0;i<=22;i++) A8_Skill12.options[i] = new Option(i + "匹",i);
 			myInnerHtml("EN812",'<Font size=2><B>攻城戦の設定は[対人プレイヤー設定]欄に移動</B></Font>',0);
-			myInnerHtml("EN813",'防衛値<select name="A8_Skill15" onChange="Click_A8(1)"></select><Font size=2>(攻城戦モード時のみ有効)</Font>',0);
+			myInnerHtml("EN813",'防衛値<select name="A8_Skill15" onChange="StAllCalc() | Click_A8(1)"></select><Font size=2>(攻城戦モード時のみ有効)</Font>',0);
 			A8_Skill15.options[0] = new Option("-",0);
 			for(i=1;i<=20;i++) A8_Skill15.options[i] = new Option(i * 5,i);
-			myInnerHtml("EN814",'<input id="OBJID_CHECK_A8_Skill16" type="checkbox" name="A8_Skill16"onClick="Click_A8(1)"><label for="OBJID_CHECK_A8_Skill16">クリティカル率を0にする</label>',0);
-			if(41 <= n_A_JOB && n_A_JOB <=43) myInnerHtml("EN819",'<input id="OBJID_CHECK_A8_Skill19" type="checkbox" name="A8_Skill19"onClick="Click_A8(1)"><label for="OBJID_CHECK_A8_Skill19"><Font size=2>暖かい風欄を他職からの武器属性付与にする<BR>　（素手Atk部分には武器属性付与が適用されない）</Font></label>',0);
-			else myInnerHtml("EN819",'<input id="OBJID_CHECK_A8_Skill19" type="checkbox" name="A8_Skill19"onClick="Click_A8(1)"><label for="OBJID_CHECK_A8_Skill19"><Font size=2>武器属性付与をアカデミーの看板型付与にする<BR>　（素手Atk部分にも武器属性付与が適用される）</Font></label>',0);
+			myInnerHtml("EN814",'<input id="OBJID_CHECK_A8_Skill16" type="checkbox" name="A8_Skill16"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A8_Skill16">クリティカル率を0にする</label>',0);
+			if(41 <= n_A_JOB && n_A_JOB <=43) myInnerHtml("EN819",'<input id="OBJID_CHECK_A8_Skill19" type="checkbox" name="A8_Skill19"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A8_Skill19"><Font size=2>暖かい風欄を他職からの武器属性付与にする<BR>　（素手Atk部分には武器属性付与が適用されない）</Font></label>',0);
+			else myInnerHtml("EN819",'<input id="OBJID_CHECK_A8_Skill19" type="checkbox" name="A8_Skill19"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A8_Skill19"><Font size=2>武器属性付与をアカデミーの看板型付与にする<BR>　（素手Atk部分にも武器属性付与が適用される）</Font></label>',0);
 
-			myInnerHtml("EN830",'クァグマイア<select name="A_IJYOU0" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN830",'クァグマイア<select name="A_IJYOU0" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A_IJYOU0.options[0] = new Option("-",0);
 			for(i=1;i<=5;i++) A_IJYOU0.options[i] = new Option("Lv"+i+"(モンスターが使用)",i);
 			for(i=6;i<=10;i++) A_IJYOU0.options[i] = new Option("Lv"+(i-5)+"(プレイヤーが使用)",i);
 
-			myInnerHtml("EN831",'速度減少<select name="A_IJYOU1" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN831",'速度減少<select name="A_IJYOU1" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A_IJYOU1.options[0] = new Option("-",0);
 			for(i=1;i<=10;i++) A_IJYOU1.options[i] = new Option("Lv"+i,i);
 			A_IJYOU1.options[11] = new Option("Lv46",46);
 			A_IJYOU1.options[12] = new Option("Lv48",48);
 
-			myInnerHtml("EN832",'<input id="OBJID_CHECK_A_IJYOU2" type="checkbox" name="A_IJYOU2"onClick="Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU2">毒</label>',0);
+			myInnerHtml("EN832",'<input id="OBJID_CHECK_A_IJYOU2" type="checkbox" name="A_IJYOU2"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU2">毒</label>',0);
 
-			myInnerHtml("EN833",'<input id="OBJID_CHECK_A_IJYOU3" type="checkbox" name="A_IJYOU3"onClick="Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU3">呪い</label>',0);
+			myInnerHtml("EN833",'<input id="OBJID_CHECK_A_IJYOU3" type="checkbox" name="A_IJYOU3"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU3">呪い</label>',0);
 
-			myInnerHtml("EN834",'スローキャスト<select name="A_IJYOU4" onChange="Click_A8(1)"></select>',0);
+			myInnerHtml("EN834",'スローキャスト<select name="A_IJYOU4" onChange="StAllCalc() | Click_A8(1)"></select>',0);
 			A_IJYOU4.options[0] = new Option("-",0);
 			for(i=1;i<=5;i++) A_IJYOU4.options[i] = new Option("Lv"+i,i);
 
-			myInnerHtml("EN835",'<input id="OBJID_CHECK_A_IJYOU5" type="checkbox" name="A_IJYOU5"onClick="Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU5">氷結<Font size=2>(ASPD-30%/DEF-10%/固定詠唱+50%)</Font></label>',0);
+			myInnerHtml("EN835",'<input id="OBJID_CHECK_A_IJYOU5" type="checkbox" name="A_IJYOU5"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU5">氷結<Font size=2>(ASPD-30%/DEF-10%/固定詠唱+50%)</Font></label>',0);
 
-			myInnerHtml("EN836",'<input id="OBJID_CHECK_A_IJYOU6" type="checkbox" name="A_IJYOU6"onClick="Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU6">(×)イヌハッカシャワー</label>',0);
+			myInnerHtml("EN836",'<input id="OBJID_CHECK_A_IJYOU6" type="checkbox" name="A_IJYOU6"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU6">(×)イヌハッカシャワー</label>',0);
 
-			myInnerHtml("EN837",'<input id="OBJID_CHECK_A_IJYOU7" type="checkbox" name="A_IJYOU7"onClick="Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU7">(×)ニャングラス</label>',0);
+			myInnerHtml("EN837",'<input id="OBJID_CHECK_A_IJYOU7" type="checkbox" name="A_IJYOU7"onClick="StAllCalc() | Click_A8(1)"><label for="OBJID_CHECK_A_IJYOU7">(×)ニャングラス</label>',0);
 
 			A8_Skill0.value = n_A_PassSkill8[0];
 			A8_Skill1.value = n_A_PassSkill8[1];
@@ -18556,9 +18566,11 @@ function Click_A8(n){
 	if(n==1) AutoCalc("Click_A8");
 
 	var sw=0;
-	for(var i=0;i <n_A_PassSkill8.length;i++) if(n_A_PassSkill8[i] != 0){
-		sw = 1;
-		break;
+	for(var i=0;i <n_A_PassSkill8.length;i++){
+		if(n_A_PassSkill8[i] != 0){
+			sw = 1;
+			break;
+		}
 	}
 	for(var i=0;i <n_A_IJYOU.length;i++) if(n_A_IJYOU[i] != 0){
 		sw = 1;

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -17331,8 +17331,7 @@ function Click_PassSkillSW(){
  */
 function Click_A1(n){
 
-	//if(n==1) calc();
-	if(n==1) AutoCalc();
+	if(n==1) AutoCalc("Click_A1");
 
 	var sw=0;
 
@@ -17748,8 +17747,7 @@ function Skill3SW_2(){
  * @param {*} n 再計算フラグ（n = 1 再計算する）
  */
 function Click_A3(n){
-	//if(n==1) calc();
-	if(n==1) AutoCalc();
+	if(n==1) AutoCalc("Click_A3");
 
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill3.length;i++){
@@ -17874,8 +17872,7 @@ function Click_Skill4SW(){
  * @param {*} n 再計算フラグ（n = 1 再計算する）
  */
 function Click_A4(n){
-	//if(n==1) calc();
-	if(n==1) AutoCalc();
+	if(n==1) AutoCalc("Click_A4");
 
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill4.length;i++) if(n_A_PassSkill4[i] != 0){
@@ -18312,8 +18309,7 @@ function Click_Food_Off(){
  * @param {*} n 再計算フラグ（n = 1 再計算する）
  */
 function Click_A7(n){
-	//if(n==1) calc();
-	if(n==1) AutoCalc();
+	if(n==1) AutoCalc("Click_A7");
 
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill7.length;i++) if(n_A_PassSkill7[i] != 0){
@@ -18557,8 +18553,7 @@ function Click_Skill8SW(){
  * @param {*} n 再計算フラグ（n = 1 再計算する）
  */
 function Click_A8(n){
-	//if(n==1) calc();
-	if(n==1) AutoCalc();
+	if(n==1) AutoCalc("Click_A8");
 
 	var sw=0;
 	for(var i=0;i <n_A_PassSkill8.length;i++) if(n_A_PassSkill8[i] != 0){
@@ -19168,12 +19163,57 @@ function GetIkariPow(mobData) {
 
 /**
  * 各種パラメータ変更時の自動計算機能
- *
+ * @param {*} callFrom 関数呼び出し元
+ * 						undefined									: 基本ステータス、特性ステータス、装備
+ * 						CConfBase.OnChangeValueHandler				: 支援設定、性能カスタマイズ
+ * 						OnChangeMobConfDebuf						: モンスター状態異常設定
+ * 						OnChangeMobConfBuf							: モンスター状態強化設定
+ * 						OnChangeMobConfPlayer						: 対プレイヤー設定
+ * 						OnChangeSettingAutoSpell					: オートスペル設定 (テスト中)
+ * 						CTimeItemAreaComponentManager.OnChangeConf	: アイテム時限効果
+ * 						RefreshSkillColumnHeaderLearned				: 習得スキル（装備効果用）
+ * 						Click_A1									: パッシブ持続系
+ * 						Click_A3									: 演奏/踊り系スキル
+ * 						Click_A4									: ギルドスキル/ゴスペル/他
+ * 						Click_A7									: アイテム(食品/他)
+ * 						Click_A8									: その他の支援/設定 (暫定追加機能)
+ * 				CAttackMethodAreaComponentManager.OnChangeAutoCalc	: 攻撃手段
+ * 		CAttackMethodAreaComponentManager.OnChangeAttackMethodOption: 攻撃手段オプション
+ * 			CAttackMethodAreaComponentManager.OnChangeAttackMethod	: 自動計算のON/OFF
  */
-function AutoCalc() {
+function AutoCalc(callFrom) {
 	// 自動設定が有効の場合のみ、再計算する
-	if (HtmlGetObjectCheckedById("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", "checked")) {
-		calc();
+	var autoCalcFlag = HtmlGetObjectValueByIdAsInteger("OBJID_INPUT_ATTACK_METHOD_AUTO_CALC", 0);
+	switch (autoCalcFlag) {
+		case 1: // 攻撃方法変更時に自動で再計算する
+			if (callFrom === "CAttackMethodAreaComponentManager.OnChangeAttackMethod"
+				|| callFrom === "CAttackMethodAreaComponentManager.OnChangeAttackMethodOption"
+				|| callFrom === "CAttackMethodAreaComponentManager.OnChangeAutoCalc"
+				) {
+					calc();
+				}
+		case 0: // 攻撃方法変更時に自動で再計算しない
+			if (callFrom === "CConfBase.OnChangeValueHandler"
+				|| callFrom === "OnChangeMobConfDebuf"
+				|| callFrom === "OnChangeMobConfBuf"
+				|| callFrom === "OnChangeMobConfPlayer"
+				|| callFrom === "OnChangeSettingAutoSpell"
+				|| callFrom === "CTimeItemAreaComponentManager.OnChangeConf"
+				|| callFrom === "RefreshSkillColumnHeaderLearned"
+				|| callFrom === "Click_A1"
+				|| callFrom === "Click_A3"
+				|| callFrom === "Click_A4"
+				|| callFrom === "Click_A7"
+				|| callFrom === "Click_A8"
+				) {
+					calc();
+				}
+			break;
+		case 2:	// 全ての項目変更時に自動で再計算しない
+			break;
+		case 3: // 全ての項目変更時に自動で再計算する
+			calc();
+			break;
 	}
 }
 

--- a/roro/m/js/CConfBase.js
+++ b/roro/m/js/CConfBase.js
@@ -673,8 +673,7 @@ function CConfBase(confArray) {
 
 		// 再計算フラグが立っている場合は、再計算を実行
 		if (bCalc) {
-			//calc();
-			AutoCalc();
+			AutoCalc("CConfBase.OnChangeValueHandler");
 		}
 	}
 

--- a/roro/m/js/CTimeItemAreaComponentManager.js
+++ b/roro/m/js/CTimeItemAreaComponentManager.js
@@ -183,8 +183,7 @@ CTimeItemAreaComponentManager.OnChangeConf = function (idxConf, dataId) {
 	}
 
 	// 再計算
-	//calc();
-	AutoCalc();
+	AutoCalc("CTimeItemAreaComponentManager.OnChangeConf");
 
 	// クイック調整欄の更新
 	CBattleQuickControlAreaComponentManager.RebuildControls();

--- a/roro/m/js/learnedskill.js
+++ b/roro/m/js/learnedskill.js
@@ -322,7 +322,7 @@ function RefreshSkillColumnHeaderLearned(objSelect, changedIdx, newValue) {
 
 	if (0 <= changedIdx) {
 		n_A_LearnedSkill[changedIdx] = parseInt(newValue);
-		AutoCalc();
+		AutoCalc("RefreshSkillColumnHeaderLearned");
 	}
 
 	// 背景設定

--- a/roro/m/js/mobconfbuf.js
+++ b/roro/m/js/mobconfbuf.js
@@ -817,7 +817,7 @@ function OnChangeMobConfBuf(bCalc) {
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
 		//calc();
-		AutoCalc();
+		AutoCalc("OnChangeMobConfBuf");
 	}
 }
 

--- a/roro/m/js/mobconfdebuf.js
+++ b/roro/m/js/mobconfdebuf.js
@@ -1300,8 +1300,7 @@ function OnChangeMobConfDebuf(bCalc) {
 
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
-		//calc();
-		AutoCalc();
+		AutoCalc("OnChangeMobConfDebuf");
 	}
 }
 

--- a/roro/m/js/mobconfplayer.js
+++ b/roro/m/js/mobconfplayer.js
@@ -1254,8 +1254,7 @@ function OnChangeMobConfPlayer(bCalc) {
 
 	// 再計算フラグが立っている場合は、再計算を実行
 	if (bCalc) {
-		//calc();
-		AutoCalc();
+		AutoCalc("OnChangeMobConfPlayer");
 	}
 }
 


### PR DESCRIPTION
## 設定変更時の自動計算の挙動を４パターンに分割しました

0. 攻撃方法変更時に自動で再計算しない（避難所と同じ仕様）
1. 攻撃方法変更時に自動で再計算する（避難所と同じ仕様）
2. 全ての項目変更時に自動で再計算しない
3. 全ての項目変更時に自動で再計算する

この選択肢の並び順は後方互換性を意識したものです

避難所の仕様では

攻撃方法変更時に自動で再計算しない = 0 (false)
攻撃方法変更時に自動で再計算する = 1 (true)

こうなっていますので、多くの利用者は今回の仕様変更を意識せず使い続けることができると思います

#304 
#313 