### PR TITLE
画像保存不具合修正

### DIFF
--- a/ro4/m/js/saveimage.js
+++ b/ro4/m/js/saveimage.js
@@ -208,6 +208,11 @@ $(function () {
       color: rgb(41, 57, 99);
     }
 
+    #imgdiv table.etc .denom {
+      font-size: 7px;
+      font-color: gray;
+    }
+
     #imgdiv table.elm {
       width: 100%;
       border-collapse: collapse;
@@ -481,7 +486,7 @@ $(function () {
             <th>ディレイ減</th>
             <td>${delayDownForDisp} %</td>
             <th>ステ無詠唱</th>
-            <td>${CExtraInfoAreaComponentManager.charaData[CHARA_DATA_INDEX_CAST_PARAM]} (< 265)</td>
+            <td>${CExtraInfoAreaComponentManager.charaData[CHARA_DATA_INDEX_CAST_PARAM]} <span class="denom"> / 265<span></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
#320 で追加したステ無詠唱の表記不具合（常に「<265」）

拡張表示のものが動的に変わるとか何も考えずに、その時表示されていた
ものをそのままスタティックな文字列で貼り付けてました💦
切り替えるほどでもないと思うので、分母表示「/ 265」にしました