### PR TITLE
モンスター状態異常に「サウンドブレンド状態」を追加

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -3732,10 +3732,11 @@ g_bUnknownCasts = true;
 			wbairitu *= n_A_BaseLV / 100;
 			break;
 
+		// ロゼブロッサム
 		case SKILL_ID_ROSE_BLOSSOM:
 
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
+			// TODO: 詠唱時間等未実測スキル
+			g_bUnknownCasts = true;
 
 			// 弓・楽器・鞭装備状態のみ発動可能
 			switch (n_A_WeaponType) {
@@ -3762,10 +3763,10 @@ g_bUnknownCasts = true;
 					// 基本倍率
 					wbairitu = 50 + (50 * n_A_ActiveSkillLV);
 
-					// TODO: 敵がサウンドブレンド状態補正未対応
-					// if () {
-					//	wbairitu += 100;
-					//}
+					// サウンドブレンド補正
+					if (n_B_IJYOU[MOB_CONF_DEBUF_ID_SOUND_BLEND]) {
+						wbairitu += 100;
+					}
 
 					// CON補正
 					wbairitu += 1 * GetTotalSpecStatus(MIG_PARAM_ID_CON);
@@ -3780,10 +3781,10 @@ g_bUnknownCasts = true;
 					// 基本倍率
 					wbairitu = 2000 + (200 * n_A_ActiveSkillLV);
 
-					// TODO: 敵がサウンドブレンド状態補正未対応
-					// if () {
-					//	wbairitu += 1000;
-					//}
+					// サウンドブレンド補正
+					if (n_B_IJYOU[MOB_CONF_DEBUF_ID_SOUND_BLEND]) {
+						wbairitu += 1000;
+					}
 
 					// CON補正
 					wbairitu += 10 * GetTotalSpecStatus(MIG_PARAM_ID_CON);
@@ -3800,6 +3801,7 @@ g_bUnknownCasts = true;
 			}
 			break;
 
+		// リズムシューティング
 		case SKILL_ID_RHYTHM_SHOOTING:
 
 // TODO: 詠唱時間等未実測スキル
@@ -3827,10 +3829,10 @@ g_bUnknownCasts = true;
 				// 基本倍率
 				wbairitu = 1000 + (100 * n_A_ActiveSkillLV);
 
-				// TODO: 敵がサウンドブレンド状態補正未対応
-				// if () {
-				//	wbairitu += 500 + (100 * n_A_ActiveSkillLV);
-				//}
+				// サウンドブレンド補正
+				if (n_B_IJYOU[MOB_CONF_DEBUF_ID_SOUND_BLEND]) {
+					wbairitu += 500 + (100 * n_A_ActiveSkillLV);
+				}
 
 				// CON補正
 				wbairitu += 5 * GetTotalSpecStatus(MIG_PARAM_ID_CON);
@@ -8644,15 +8646,32 @@ g_bDefinedDamageIntervals = true;
 			wbairitu = ROUNDDOWN(wbairitu * n_A_BaseLV / 100);
 			break;
 
+		// メタリックサウンド
 		case SKILL_ID_METALIC_SOUND:
 			n_A_Weapon_zokusei = 0;
 			n_bunkatuHIT = 1;
-			wHITsuu = Math.min(4, 1 + Math.floor((1 + n_A_ActiveSkillLV) / 2));
 			wCast = Math.min(3000, 500 + 500 * n_A_ActiveSkillLV);
 			n_Delay[7] = 200;
-			wbairitu = 120 * n_A_ActiveSkillLV + 60 * UsedSkillSearch(SKILL_ID_LESSON);
+
+			// 基本倍率
+			wbairitu = 120 * n_A_ActiveSkillLV
+
+			// サウンドブレンド補正
+			if (n_B_IJYOU[MOB_CONF_DEBUF_ID_SOUND_BLEND] > 0) {
+				wbairitu *= 2;
+			}
+			
+			// レッスン補正
+			wbairitu += 60 * UsedSkillSearch(SKILL_ID_LESSON);
+
+			// BaseLv補正
 			wbairitu = ROUNDDOWN(wbairitu * n_A_BaseLV / 100);
-			if(n_B_IJYOU[8]) wbairitu = ROUNDDOWN(wbairitu * 150 / 100);
+
+			// 睡眠補正
+			if(n_B_IJYOU[MOB_CONF_DEBUF_ID_SUIMIN]) {
+				wbairitu = ROUNDDOWN(wbairitu * 150 / 100);
+			} 
+
 			break;
 
 		case SKILL_ID_FIRE_WALK:
@@ -9798,10 +9817,11 @@ g_bDefinedDamageIntervals = true;
 			}
 			break;
 
+		// メタリックフューリー
 		case SKILL_ID_METALIC_FURY:
 
-// TODO: 詠唱時間等未実測スキル
-g_bUnknownCasts = true;
+			// TODO: 詠唱時間等未実測スキル
+			g_bUnknownCasts = true;
 
 			// 楽器・鞭装備状態のみ発動可能
 			switch (n_A_WeaponType) {

--- a/roro/m/js/mobconfdebuf.js
+++ b/roro/m/js/mobconfdebuf.js
@@ -780,7 +780,7 @@ function InitMobConfDebufData() {
 		MobConfDebufMaxValue(1)
 	];
 	MobConfDebufOBJ[MobConfDebufId] = MobConfDebufData;
-	MobConfDebufId++;	
+	MobConfDebufId++;
 
 
 	MOB_CONF_DEBUF_ID_SEIYU_SENREI_DEBUFF = MobConfDebufId;
@@ -793,7 +793,20 @@ function InitMobConfDebufData() {
 		MobConfDebufMaxValue(5)
 	];
 	MobConfDebufOBJ[MobConfDebufId] = MobConfDebufData;
-	MobConfDebufId++;	
+	MobConfDebufId++;
+
+
+	MOB_CONF_DEBUF_ID_SOUND_BLEND = MobConfDebufId;
+	MobConfDebufData = [
+		MobConfDebufId,
+		MobConfDebufText("サウンドブレンド状態"),
+		MobConfDebufControlType(CONTROL_TYPE_CHECKBOX),
+		MobConfDebufDefaultValue(0),
+		MobConfDebufMinValue(0),
+		MobConfDebufMaxValue(1)
+	];
+	MobConfDebufOBJ[MobConfDebufId] = MobConfDebufData;
+	MobConfDebufId++;
 
 
 	//----------------------------------------------------------------
@@ -823,6 +836,7 @@ function InitMobConfDebufData() {
 	// 表示順序に従い、状態異常データ定義を再配列
 	//----------------------------------------------------------------
 	MobConfDebufOBJSorted = new Array();
+
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_PROVOKE];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_QUAGMIRE];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_DOKU];
@@ -833,6 +847,7 @@ function InitMobConfDebufData() {
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_STUN];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SUIMIN];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SEKIKA];
+
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_NOROI];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SOKUDO_GENSHO];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SIGNUM_CRUCIS];
@@ -843,6 +858,7 @@ function InitMobConfDebufData() {
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_STRIP_ACCESSARY];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SPIDER_WEB];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_MIND_BREAKER];
+
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_WATASHIWO_WASURENAIDE];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_EIENNNO_KONTON];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_ESKA];
@@ -853,6 +869,7 @@ function InitMobConfDebufData() {
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_ENERVATION];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_GROOMY];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_ORATIO];
+
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_HAKKA];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SURPRISE_ATTACK_EFFECT];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_HYOKETSU];
@@ -863,6 +880,7 @@ function InitMobConfDebufData() {
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_MAHI];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_RAKUIN_ZYOTAI];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_INUHAKKA_SHOWER];
+
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_NYAN_GRASS];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_TARONO_KIZU];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_KAITO];
@@ -872,6 +890,8 @@ function InitMobConfDebufData() {
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_EARTH_DRIVE_DEBUFF];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_QUAKE_DEBUFF];
 	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SEIYU_SENREI_DEBUFF];
+	MobConfDebufOBJSorted[MobConfDebufOBJSorted.length] = MobConfDebufOBJ[MOB_CONF_DEBUF_ID_SOUND_BLEND];
+
 	MobConfDebufOBJ = MobConfDebufOBJSorted;
 
 }


### PR DESCRIPTION
### メタリックサウンドの多段Hitを修正
現在のゲーム内仕様では1Hitに統一されている

#347

### モンスター状態異常に「サウンドブレンド状態」を追加

### サウンドブレンド状態が影響するスキルの計算式を修正
- メタリックサウンド
- メタリックフューリー
- ロゼブロッサム
- リズムシューティング

#348