### PR TITLE
android環境で発生する重大な問題のhotfix

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -259,7 +259,7 @@
 	<!-- jQuery function 初回実行 -->
 	<script>
 		$(document).ready(function() {
-			if (navigator.userAgent.match(/iPhone|Android.+Mobile/)) {
+			if (navigator.userAgent.match(/iPhone/)) {
 				$(".wrapper .content").css("overflow","initial");
 			}
 			// エンチャントサーチのロード


### PR DESCRIPTION
android環境で
> $(".wrapper .content").css("overflow","initial");

を実行するとスクロールを上に戻せなくなる事象を確認したので
暫定処置としてiPhoneのみでこれが発火するように修正しました
