### PR TITLE
hotfix: android環境で発生する問題の修正パッチ

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -262,6 +262,10 @@
 			if (navigator.userAgent.match(/iPhone/)) {
 				$(".wrapper .content").css("overflow","initial");
 			}
+			else if (navigator.userAgent.match(/Android/)) {
+				$(".wrapper").css("overflow","scroll");
+				$(".content").css("overflow","visible");
+			}
 			// エンチャントサーチのロード
 			new enchSearch();
 			// 検索可能ドロップダウンリストのロード


### PR DESCRIPTION
android + chrome ではサイドメニューを scroll、計算機本体を visibleに明示することでスムーズなスクロールが可能になりました
ただし iphone + safari ではこの設定は期待したように動かない（修正前と同じようにスクロールが引っかかる）ので iphone と android で場合分けして対応しています