### PR TITLE
H.Plus 加算を示す ItemSP が正しく処理されない不具合を修正

### DIFF
--- a/ro4/m/js/hmjob.js
+++ b/ro4/m/js/hmjob.js
@@ -884,8 +884,8 @@ function GetHPlus() {
 	value += GetTotalSpecStatus(MIG_PARAM_ID_CRT);
 
 	// 装備効果
-	value += n_tok[ITEM_SP_HPLUS_PLUS];
-	value += GetRndOptTotalValue(ITEM_SP_HPLUS_PLUS);
+	value += n_tok[ITEM_SP_H_PLUS_PLUS];
+	value += GetRndOptTotalValue(ITEM_SP_H_PLUS_PLUS);
 
 
 

--- a/roro/m/js/item.h.js
+++ b/roro/m/js/item.h.js
@@ -628,11 +628,15 @@ CGlobalConstManager.DefineEnum(
 
 		"ITEM_SP_P_ATK_PLUS",
 		"ITEM_SP_S_MATK_PLUS",
-		"ITEM_SP_H_PLUS_PLUS",
+		"ITEM_SP_H_PLUS_PLUS",				// 252 H.Plus 加算
 		"ITEM_SP_C_RATE_PLUS",
 		"ITEM_SP_RES_PLUS",
 		"ITEM_SP_MRES_PLUS",
-		"ITEM_SP_HPLUS_PLUS",
+		// 未使用と思われますがコードを追いきれないのでエラー炙り出すために名前を置き換えます
+		// ITEM_SP_HPLUS_PLUS → ITEM_SP_RESERVED_256 
+		// ITEM_SP_HPLUS_PLUS が見つからない旨のエラーが出力されないか、しばらく注視してください
+		// 2024.04.11 usachoco
+		"ITEM_SP_RESERVED_256",				
 		"ITEM_SP_RESERVED_257",				// 未使用（257）
 		"ITEM_SP_RESERVED_258",				// 未使用（258）
 		"ITEM_SP_RESERVED_259",				// 未使用（259）


### PR DESCRIPTION
#372 

オルタネイトアーマーのH.Plus加算
溶解したポリンのH.Plus加算

が正しく機能しない問題を修正しました