### PR TITLE
セーブデータ名の最大長さを40に拡張しました

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -304,7 +304,7 @@
 								<div class="folding-block-body-MIG">
 									<select id="OBJID_SELECT_SAVE_DATA_MIG">
 									</select>
-									<input id="OBJID_INPUT_SAVE_NAME_MIG" type="textbox" size="24" placeholder="名前入力可能（20文字まで）">
+									<input id="OBJID_INPUT_SAVE_NAME_MIG" type="textbox" size="24" placeholder="名前入力可能（40文字まで）">
 									<input type="button" id="save_image" style="width:5em;margin-left:1em;" value="画像保存">
 
 									<button id="OBJID_BUTTON_LOAD_SAVE_DATA_MIG" type="button" onclick="OnClickLoadSaveData() | LoadSelect2()">ロード</button>

--- a/ro4/m/js/CSaveController.js
+++ b/ro4/m/js/CSaveController.js
@@ -49,7 +49,7 @@ class CSaveController {
 	 * キャラクターデータの名前の文字列長.
 	 */
 	static get CHARA_DATA_NAME_LENGTH () {
-		return 20;
+		return 40;
 	}
 
 	/**


### PR DESCRIPTION
40文字でセーブしたあとにソースコードを切り戻しても（20文字上限に戻しても）セーブデータに不具合が出ないことを確認済みです もし何らかの見落としがあってコードを切り戻す必要に迫られた場合でも問題は無いと思います

#363