### PR TITLE
オプション画面の追加

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -256,6 +256,7 @@
 	<script type="text/javascript" src="../../ro4/m/js/calchistory.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js" integrity="sha512-3j3VU6WC5rPQB4Ld1jnLV7Kd5xr+cq9avvhwqzbH/taCRNURoeEpoPBK9pDyeukwSxwRPJ8fDgvYXd6SkaZ2TA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script type="text/javascript" src="../../ro4/m/js/cookiemanager.js"></script>
+	<script type="text/javascript" src="../../ro4/m/js/storagemanager.js"></script>
 	<!-- jQuery function 初回実行 -->
 	<script>
 		$(document).ready(function() {

--- a/ro4/m/config.css
+++ b/ro4/m/config.css
@@ -1,0 +1,8 @@
+div.SECTION {
+    background-color: rgb(221,221,255);
+    padding: 2px 10px;
+}
+
+div.ITEM {
+    margin: 2px 20px;
+}

--- a/ro4/m/config.html
+++ b/ro4/m/config.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Config</title>
+        <script src="../../jquery/jquery.min.js"></script>
+        <script type="text/javascript" src="../../ro4/m/js/storagemanager.js"></script>
+        <link rel="stylesheet" href="config.css" type="text/css">
+    </head>
+    <body>
+        <div class="SECTION">
+            <span>表示する情報</span>
+        </div>
+        <div class="ITEM">
+            <input type="checkbox" id="OBJID_OPTION_SIMPLE_BATTLE_VIEW">
+            <label for="OBJID_OPTION_SIMPLE_BATTLE_VIEW">装備欄の真下に簡易計算結果を表示する</label>
+        </div>
+
+    </body>
+</html>

--- a/ro4/m/js/storagemanager.js
+++ b/ro4/m/js/storagemanager.js
@@ -1,0 +1,37 @@
+/**
+* 計算機の状態を LocalStorage にセーブ、あるいはロードする
+* config.html から設定を変更し calcx.html で設定を反映させるので両方の html から当 js を参照すること
+*/
+$(function () {
+    // グローバル変数の初期化 (0 or 1)
+    g_op_simple_battle_view = ~~localStorage.getItem("op_simple_battle_view");
+
+    // --------------------------------
+    // 本体側の処理
+    // --------------------------------
+    if (g_op_simple_battle_view === 1) {
+        $('#OBJID_DIV_BATTLE_RESULT_TINY').show();
+        $('#OBJID_DIV_RESIST_ELEMENT_TINY').show();
+    }
+
+    // --------------------------------
+    // オプション画面(IFrame)側の処理
+    // --------------------------------
+    // 設定のロード
+    if (g_op_simple_battle_view === 1) {
+        $("#OBJID_OPTION_SIMPLE_BATTLE_VIEW").click();
+    }
+    // 各設定のチェックボックスにイベントハンドラを追加
+    $(document).on("click", "#OBJID_OPTION_SIMPLE_BATTLE_VIEW", (e) => {
+        g_op_simple_battle_view = $(e.target).prop("checked")? 1: 0;
+        localStorage.setItem("op_simple_battle_view", g_op_simple_battle_view);
+        if (g_op_simple_battle_view === 1) {
+            window.parent.$('#OBJID_DIV_BATTLE_RESULT_TINY').show();
+            window.parent.$('#OBJID_DIV_RESIST_ELEMENT_TINY').show();
+        }
+        else {
+            window.parent.$('#OBJID_DIV_BATTLE_RESULT_TINY').hide();
+            window.parent.$('#OBJID_DIV_RESIST_ELEMENT_TINY').hide();
+        }
+    });
+});

--- a/roro/frame.js
+++ b/roro/frame.js
@@ -63,7 +63,8 @@ templ = `
         </ul>
       </nav>
     </div>
-		<input type="button" value="背景色切替" onclick="SwitchBGColor()" style="margin-top: 3em;">
+    <span class="menu-title"><a href="../../ro4/m/config.html" class="BUTTON local" style="margin-top: 2em;">オプション</a></span>
+    <input type="button" value="背景色切替" onclick="SwitchBGColor()" style="margin-top: 5px;">
 		</div>
 </aside>
 <div class="modal-container">

--- a/roro/m/calcx.css
+++ b/roro/m/calcx.css
@@ -371,9 +371,11 @@ td.CSSCLS_EXTRA_INFO_DISP_TABLE_SKILL_CARD_NG {
 }
 #OBJID_DIV_BATTLE_RESULT_TINY {
 	white-space: nowrap;
+	display: none;
 }
 #OBJID_DIV_RESIST_ELEMENT_TINY {
 	white-space: nowrap;
+	display: none;
 }
 #OBJID_DIV_RESIST_ELEMENT_TINY .label {
 	font-size: small;
@@ -484,10 +486,15 @@ td.CSSCLS_EXTRA_INFO_DISP_TABLE_SKILL_CARD_NG {
 	display: none;
 }
 
-
-
-
-
-
-
-
+a.BUTTON {
+	display: inline-block;
+	border-style: solid;
+	color: black;
+	background-color: rgb(240, 240, 240);
+	border-width:1px;
+	border-color: black;
+	text-decoration: none;
+	font-size: 14px;
+	text-align: center;
+	width: 154px;
+}


### PR DESCRIPTION
これは案の一つなのでマージせずにクローズする可能性があります

左側メニューの下部にオプションボタンを追加しました。
ボタンをクリックするとオプション画面が開き
「戦闘結果の簡易表示」と「属性耐性の簡易表示」のON/OFFを切り替えることが出来ます。

![image](https://github.com/roratorio-hub/ratorio/assets/149866018/59ac35ac-7846-45e6-9d41-ac871d276656)
![image](https://github.com/roratorio-hub/ratorio/assets/149866018/f2e6b8ec-e169-4a17-a15f-524bd293c881)

### 背景

「戦闘結果の簡易表示」と「属性耐性の簡易表示」は便利なのですが、
情報量を増やしすぎると見にくくなる場合もあるので、
表示をON/OFFできるようにしておいた方が良いと思います。 

従来の方式に合わせるならば
「アイテム情報」のようにチェックボックスで開閉するウィンドウに情報を収めるところです。
しかしそれでは、将来的に開閉できるウィンドウが無数に増えてしまうかもしれないので、
オプション画面にまとめるアイデアを試してみました。

### 設定の保存方法について
storagemanager.js で LocalStorage を直接操作しています。
従来の設計では CSaveDataUnit.js にオプション項目を定義した上で
CSaveController.js を経由して LocalStorage に設定を保存しています。 
たとえば「動作設定 > 3桁区切りで表示する」がこれに該当します。

しかし、そのような複雑な処理を行う必要は無いように思いましたので
本 PR では直接操作するコードを書きました。

### 動作確認に関して
iframe で作られたオプション画面から親画面を操作するため http サーバ経由での確認が必要になります。
ratorio ルートで pyhon -m http.server するなど、httpサーバ経由での動作確認お願いします。