### PR TITLE
セーブデータ拡張

### DIFF
--- a/ro4/m/js/CSaveDataUnit.js
+++ b/ro4/m/js/CSaveDataUnit.js
@@ -5001,9 +5001,21 @@ const SAVE_DATA_UNIT_TYPE_MOB = CSaveDataUnitTypeManager.register(
 		 * バージョン番号.
 		 */
 		static get version () {
-			return 1;
+			return 2;
 		}
 
+		// オーバーライドされた parse 関数
+		parse (dataText, bitOffset) {
+			let nextOffset = super.parse(dataText, bitOffset);
+			if (this.getProp("version") == 1n) {
+				this.propInfoMap.delete(CSaveDataConst.propNameMonsterID);
+				const prop = new CSaveDataPropInfo(CSaveDataConst.propNameMonsterID, 11);
+				this.propInfoMap.set(CSaveDataConst.propNameMonsterID, prop);
+				this.parsedMap.clear();
+				nextOffset = super.parse(dataText, bitOffset);
+			}
+			return nextOffset;
+		}
 
 
 		/**
@@ -5037,7 +5049,8 @@ const SAVE_DATA_UNIT_TYPE_MOB = CSaveDataUnitTypeManager.register(
 			this.registerPropInfo(CSaveDataConst.propNameOptCode, 6);
 			this.registerPropInfo(CSaveDataConst.propNameMonsterMapCategoryID, 8);
 			this.registerPropInfo(CSaveDataConst.propNameMonsterMapID, 10);
-			this.registerPropInfo(CSaveDataConst.propNameMonsterID, 11);
+			//this.registerPropInfo(CSaveDataConst.propNameMonsterID, 11);	version 1
+			this.registerPropInfo(CSaveDataConst.propNameMonsterID, 16);
 		}
 
 


### PR DESCRIPTION
#425 に関して
セーブデータに納めることが出来るMonsterIDを11bit (2047) から16bit (65535) に拡張しました

## どういう意図で書いたのか
Issue を解決するだけでなく
現在の私達のノウハウではセーブデータ周りのメンテナンスにかかるコストが高いので
もっと低コストで汎用性のある手順を見つけたいと思って取り組みました

## やっている内容
CSaveDataUnit.js に用意されている version という変数がいかにもだったので使い方を模索しました

ro4/m/js/CSaveDataUnit.js の CSaveDataUnitBase クラスで定義された parse 関数は
継承先のクラスで必要に応じてオーバーライドすることが想定されているようです
今回は CSaveDataUnitMob クラスで parse をオーバーライドしてみました

1. まずは CSaveDataUnitMob クラスの定義を更新します
version を 2 に上げて MonsterID の長さを 16 bit に拡張します
MonsterID の長さは propInfoMap.propNameMonsterID で定義されています

2. スーパークラスの parse を使って暫定処理を行います
セーブされた時と現在の propInfoMap の定義が違うと読み取り範囲が変わるのでデータが破損しますが
とりあえず気にしないで読み込みます

3. パースされたインスタンスのバージョンを読み取ります 
仮に propInfoMap の定義が違ってもバージョンは正しく読み取ることが出来ます
バージョンが 2 の場合はスーパークラスの parse の結果を返して既存の処理を続けます
バージョンが 1 の場合はオーバーライドされた parse を行います

4. オーバーライドされた parse では propInfoMap を一旦削除して、バージョン 1 の propInfoMap で上書きします
これで古いデータを読み取る準備が整います

5. 上書きした状態で改めてスーパークラスの parse を呼び出します
この一連の処理により、古いバージョンのセーブデータを破損せず呼び出すことが出来ます

## やってないこと

セーブデータは複数のセーブデータユニットの配列として定義されており
セーブデータ自体にもバージョン番号が設定されています
今回はセーブデータユニットの一つのバージョンを上げましたが
セーブデータ自体のバージョンは上げていません

この対応が将来的に問題を引き起こさないか調査してからマージしようと思います

## 本件の対応
動作確認したところうまく動いたように見えますが
セーブデータ周りはとても慎重に触るべきだと思いますので
十分にレビューしてからマージしたいと思います

幸い #425 は急いで解決しなければならない問題ではありませんので
じっくりやろうと思います