### PR TITLE
簡易表示の固定詠唱増減率の修正

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -13294,7 +13294,7 @@ function BuildBattleResultHtmlMIG(charaData, specData, mobData, attackMethodConf
 		HtmlCreateTextNode(funcDIG3PXSecond(battleCalcResult.castFixed, 2), objCell);
 
 		let castFixedText = funcDIG3PXSecondCompact(battleCalcResult.castFixed, 2);
-		castFixedText += `(${100 - n_A_Kotei_Cast_Keigen}%)`;
+		castFixedText += `(${(100 - GetCastScalingOfSkillForCastTimeFixed(n_A_ActiveSkill)) > (100 - n_A_Kotei_Cast_Keigen) ? (100 - GetCastScalingOfSkillForCastTimeFixed(n_A_ActiveSkill)) : (100 - n_A_Kotei_Cast_Keigen)}%)`;
 		funcRenderResultTinyHtml(objGridTiny, "固定", castFixedText);
 
 		//----------------


### PR DESCRIPTION
現在選択中のスキルに対し、現在装備中の装備での増減率を表示するように修正。（装備効果の固定詠唱カット率が上回る場合はそちらを反映するように修正。）