### PR TITLE
カスタム表示 > 拡張情報 > 物理特化 に 必中%表示 を追加しました

### DIFF
--- a/roro/m/js/CExtraInfoAreaComponentManager.js
+++ b/roro/m/js/CExtraInfoAreaComponentManager.js
@@ -1702,7 +1702,18 @@ function CExtraInfoAreaComponentManager () {
 			]
 		);
 
-		loopDataArray.push(["防御無視", 0, 4, 1, specArray]);
+		loopDataArray.push(["防御無視", 0, 3, 1, specArray]);
+
+		// その他欄
+		specArray = [];
+		specArray.push(
+			[
+				["必中"],
+				CExtraInfoAreaComponentManager.specData[ITEM_SP_PERFECT_ATTACK_UP],
+				"\\%",
+			]
+		);		
+		loopDataArray.push(["その他", 3, 1, 1, specArray]);
 
 
 


### PR DESCRIPTION
必中%の値は ITEM_SP_PERFECT_ATTACK_UP の合算値を参照しています
将来的にそれ以外の値が考慮されるようになる場合はさらなる修正が必要です

#449 