### PR TITLE
アクセサリコピー機能

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -919,7 +919,8 @@
 									</tr>
 
 									<tr id="OBJID_ACCESSARY_1_SLOT_ROOT">
-										<td>
+										<td style="text-align:right">
+											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(1, 2)">↓</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | AutoCalc()"></select>
@@ -932,7 +933,8 @@
 									</tr>
 
 									<tr id="OBJID_ACCESSARY_2_SLOT_ROOT">
-										<td>
+										<td style="text-align:right">
+											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(2, 1)">↑</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_2" name="A_acces2" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2, parseInt(this.value)) | AutoCalc()"></select>

--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -920,7 +920,7 @@
 
 									<tr id="OBJID_ACCESSARY_1_SLOT_ROOT">
 										<td style="text-align:right">
-											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(1, 2)">↓</button>
+											<button type="button" id="OBJID_ACCESSARY_1_COPY" onclick="copyAccs(1, 2)">↓</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | AutoCalc()"></select>

--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -1928,3 +1928,27 @@ function IsLongRange(itemId) {
 	// ここまで来たら、遠距離でない
 	return false;
 }
+
+function copyAccs(from, to){
+	// ランダムオプション入力中はelementがないので処理できない
+	// 中途半端になるので何もしないようにする
+	if (GetSlotMode() != SLOTPAGER_MODE_CARD) {
+		return;
+	}
+
+	const id_from = "#OBJID_ACCESSARY_"+from;
+	const id_to = "#OBJID_ACCESSARY_"+to;
+	const accs_from = $(id_from).val();
+
+	if ($(`${id_to} option[value=${accs_from}]`).length>0) {
+		$(id_to).val(accs_from).change().trigger("select2:select");
+		[1,2,3,4].forEach((i)=>{
+			$(`${id_to}_CARD_${i}`).prop("selectedIndex", $(`${id_from}_CARD_${i}`).prop("selectedIndex")).change();
+		})
+	} else {
+		$(id_to).prop("selectedIndex", 0).change();
+		[1,2,3,4].forEach((i)=>{
+			$(`${id_to}_CARD_${i}`).prop("selectedIndex", 0).change();
+		})
+	}
+}


### PR DESCRIPTION
## アクセサリコピー
要望は入替になっていますが、操作として入替て終わりでなくコピー元アクセを別のものに変更するまでが
一連の操作になるはずなので、「AからBへコピー」で十分事足りると判断

> 入れ替えて効果が変わるアクセ・カードは極小数しかなく、
> 位置固定のアクセを切り替えたい（「1+フリー」を「フリー+2」にする）という使い方がメインになるはず。

### 対応
各アクセの先頭（他部位では精錬値の選択がある列）に以下ボタンを追加
（なんの拘りもなくあいてるとこに入れただけ）
- 「↓」1を2へコピー
- 「↑」2を1へコピー

### ISSUE
#451 
