### PR TITLE
アクセサリ入れ替えボタンにSelect2初期化イベントを追加

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -920,7 +920,7 @@
 
 									<tr id="OBJID_ACCESSARY_1_SLOT_ROOT">
 										<td style="text-align:right">
-											<button type="button" id="OBJID_ACCESSARY_1_COPY" onclick="copyAccs(1, 2)">↓</button>
+											<button type="button" id="OBJID_ACCESSARY_1_COPY" onclick="copyAccs(1, 2) | LoadSelect2()">↓</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | AutoCalc()"></select>
@@ -934,7 +934,7 @@
 
 									<tr id="OBJID_ACCESSARY_2_SLOT_ROOT">
 										<td style="text-align:right">
-											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(2, 1)">↑</button>
+											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(2, 1) | LoadSelect2()">↑</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_2" name="A_acces2" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2, parseInt(this.value)) | AutoCalc()"></select>


### PR DESCRIPTION
「アルファコア」と「海底神殿の秘宝」に他方のアクセ情報をコピーすると
カード欄がSelect2化されない問題を解消するものです
この２つは例外的にSlot1がエンチャントであるためこの対処を追加しようと思います

- 例：アクセ2のSlot1の外観がおかしくなる様子
![image](https://github.com/user-attachments/assets/02cfa362-fbc2-47ad-9e8f-a65f1deffa5a)
↓
![image](https://github.com/user-attachments/assets/cb8b28cb-6463-446c-9622-95f127746f27)

#499 
#451