### PR TITLE
エンチャント検索機能のbugfix

### DIFF
--- a/ro4/m/js/CEnchSearch.js
+++ b/ro4/m/js/CEnchSearch.js
@@ -130,6 +130,7 @@ class enchSearch {
                                     if(resSelect.value && select.value !== resSelect.value){
                                             select.value = resSelect.value;
                                             select.dispatchEvent(new Event('change'));
+                                            select.dispatchEvent(new Event('select2:select'));
                                     }
                             });
                             select.parentNode.setAttribute('style', 'position:relative; padding-top:30px;');


### PR DESCRIPTION
エンチャント検索から装備をセットしたときに一部の装備でエンチャント欄が意図せずselect2化してしまう問題を修正
改善提案：rag769さん

#346