### PR TITLE
セーブデータ周りの問題を修正

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -240,7 +240,9 @@
 
 	<!-- その他、機能系 javascript ファイル -->
 	<script type="text/javascript" src="js/castsim.js"></script>
+<!--
 	<script type="text/javascript" src="js/browsermigration.js"></script>
+-->	
 	<script type="text/javascript" src="../../ro4/m/js/CEnchSearch.js"></script>
 
 	<!-- ここからjQuery -->
@@ -1890,10 +1892,10 @@
 				<hr>
 
 				<p style="font-weight: bold;">
-					以下のセーブ・ロード機能は旧バージョンのため一部のデータを保存することができません<br>
-					近々撤去する予定なので今後は<a href="../../ro4/m/calcx.html#OBJID_SAVE_BLOCK_MIG">最新版のセーブ・ロード機能</a>をご利用下さい
+					旧バージョンのセーブ・ロード機能は撤去しました<br>
+					今後は<a href="../../ro4/m/calcx.html#OBJID_SAVE_BLOCK_MIG">最新版のセーブ・ロード機能</a>をご利用下さい
 				</p>
-
+				<!--
 				<table>
 					<tr>
 						<td>
@@ -1912,9 +1914,7 @@
 						</td>
 					</tr>
 				</table>
-
 				<br>
-
 				<table>
 					<tr>
 						<td>
@@ -1933,9 +1933,7 @@
 						</td>
 					</tr>
 				</table>
-
 				<hr>
-
 				<table>
 					<tbody>
 						<tr>
@@ -1944,6 +1942,7 @@
 						</tr>
 					</tbody>
 				</table>
+				-->
 
 				<table>
 					<tbody>
@@ -1962,7 +1961,6 @@
 						</tr>
 					</tbody>
 				</table>
-
 				<table>
 					<tbody>
 						<tr>
@@ -1971,16 +1969,8 @@
 						</tr>
 					</tbody>
 				</table>
-
-
-
 				<div id="OBJID_RRTGET_ROOT"></div>
-
-
-
 			</form>
-
-
 
 			<table border="1" style="display: none;">
 				<tbody>

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30911,7 +30911,7 @@ function Init(){
 	catch (err) {
 	}
 
-	OnClickBrowserMigrationSwitch();
+//	OnClickBrowserMigrationSwitch();
 
 	CItemInfoManager.RebuildControls();
 


### PR DESCRIPTION
旧形式のセーブデータを新形式に変換する際に
セーブデータユニットのプロパティ数の違いにより正しく変換できない問題がありました

また、いつまでも過去のバージョンを考慮して開発を続けることは負担が大きいため、
この機会に古いセーブ・ロードのUIを撤去しました
少しずつ古い形式のセーブデータの流通量が減り、後方互換性を考慮しなくて良くなることを期待しています

#532