### PR TITLE
アクセ入れ替え時にSelect2が適用されない場合がある問題の対応

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -984,7 +984,7 @@
 										<td>
 										</td>
 										<td style="text-align:right">
-											<button type="button" id="OBJID_ACCESSARY_1_COPY" onclick="copyAccs(1, 2) | LoadSelect2()">↓</button>
+											<button type="button" id="OBJID_ACCESSARY_1_COPY" onclick="copyAccs(1, 2)">↓</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_1" name="A_acces1" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1, parseInt(this.value)) | AutoCalc()"></select>
@@ -1000,7 +1000,7 @@
 										<td>
 										</td>
 										<td style="text-align:right">
-											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(2, 1) | LoadSelect2()">↑</button>
+											<button type="button" id="OBJID_ACCESSARY_2_COPY" onclick="copyAccs(2, 1)">↑</button>
 										</td>
 										<td>
 											<select id="OBJID_ACCESSARY_2" name="A_acces2" onChange="OnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2, parseInt(this.value)) | AutoCalc()"></select>

--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -1962,7 +1962,7 @@ function copyAccs(from, to){
 			$(`${id_to}_CARD_${i}`).prop("selectedIndex", $(`${id_from}_CARD_${i}`).prop("selectedIndex")).change();
 		})
 	} else {
-		$(id_to).prop("selectedIndex", 0).change();
+		$(id_to).prop("selectedIndex", 0).change().trigger("select2:select");
 		[1,2,3,4].forEach((i)=>{
 			$(`${id_to}_CARD_${i}`).prop("selectedIndex", 0).change();
 		})


### PR DESCRIPTION
暫定処置としてHTML側で無理やりLoadSelect2()を呼び出していましたが
equip.jsのSlect2操作部分で根本解決出来たのでHTML側コードを削除しました

## 概要

アクセサリのコピーボタンをクリックした時に
コピー先にアクセサリを入力できる場合は Select2 がリセットされますが
アクセサリを入力出来ずに空欄になってしまう場合は Select2 がリセットされない状態でした

多くのアクセサリはSlot1にカードが刺さる（= Select2 化されている）ので問題にならないのですが
以下のようなケースでは問題が生じます

アルファコア：Slot1 がエンチャントなので Select2 化されていない
↓
空欄：Slot1 がカードなので Select2 化される必要がある

## 対応

コピー先が空欄になってしまう場合でも
Select2 をリセットするように修正しました

## 関連Issue, PR

- #451
- #499 
- #501 