### PR TITLE
詠唱シミュレータに消費APの表示を追加等

### DIFF
--- a/roro/m/js/CCalcDataTextCreator.js
+++ b/roro/m/js/CCalcDataTextCreator.js
@@ -194,6 +194,7 @@ CCalcDataTextCreator.CreateCalcDataText = function (testLabel) {
 		textResult += "OBJID_TD_CAST_SIM_CAST_TIME_FORCE_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_CAST_TIME_FORCE_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_DELAY_TIME_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_DELAY_TIME_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_COOL_TIME_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_COOL_TIME_" + idx, undefined) + ";\r\n";
+		textResult += "OBJID_TD_CAST_SIM_LIFETIME_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_LIFETIME_" + idx, undefined) + ";\r\n";
 	}
 
 	textResult += ("\r\n").repeat(3);

--- a/roro/m/js/CCalcDataTextCreator.js
+++ b/roro/m/js/CCalcDataTextCreator.js
@@ -188,6 +188,7 @@ CCalcDataTextCreator.CreateCalcDataText = function (testLabel) {
 		textResult += "OBJID_CONTROL_CAST_SIM_SKILL_SELECT_" + idx + " = " + HtmlGetObjectValueByIdAsInteger("OBJID_CONTROL_CAST_SIM_SKILL_SELECT_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_CONTROL_CAST_SIM_LEVEL_SELECT_" + idx + " = " + HtmlGetObjectValueByIdAsInteger("OBJID_CONTROL_CAST_SIM_LEVEL_SELECT_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_COST_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_COST_" + idx, undefined) + ";\r\n";
+		textResult += "OBJID_TD_CAST_SIM_COSTAP_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_COSTAP_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_CAST_TIME_VARY_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_CAST_TIME_VARY_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_CAST_TIME_FIXED_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_CAST_TIME_FIXED_" + idx, undefined) + ";\r\n";
 		textResult += "OBJID_TD_CAST_SIM_CAST_TIME_FORCE_" + idx + " = " + funcGetChildText("OBJID_TD_CAST_SIM_CAST_TIME_FORCE_" + idx, undefined) + ";\r\n";

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -31906,7 +31906,7 @@ function CSkillManager() {
 			this.element = CSkillData.ELEMENT_VOID;
 
 			this.CostFixed = function(skillLv, charaDataManger) {
-				return 120;
+				return 170;
 			}
 
 			this.CastTimeVary = function(skillLv, charaDataManger) {

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -82,6 +82,9 @@ function CSkillData() {
 	this.CoolTime = function(skillLv, charaDataManger) {
 		return 0;
 	}
+	this.LifeTime = function(skillLv, charaDataManger) {
+		return 0;
+	}
 
 	// クリティカル発生率を取得（0:発生しない、100:等倍、etc...）
 	this.CriActRate = function(skillLv, charaData, specData, mobData) {
@@ -247,6 +250,10 @@ function CSkillManager() {
 
 	this.GetCoolTime = function(skillId, skillLv, charaDataManger) {
 		return this.dataArray[skillId].CoolTime(skillLv, charaDataManger);
+	}
+
+	this.GetLifeTime = function(skillId, skillLv, charaDataManger) {
+		return this.dataArray[skillId].LifeTime(skillLv, charaDataManger);
 	}
 
 	this.IsEnableCritical = function(skillId, skillLv, charaData, specData, mobData) {
@@ -24632,6 +24639,10 @@ function CSkillManager() {
 				return 300000;
 			}
 
+			this.LifeTime = function(skillLv, charaDataManger) {
+				return 60000;
+			}
+
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;
@@ -31837,6 +31848,9 @@ function CSkillManager() {
 			}
 			this.CostAP = function(skillLv, charaDataManger) {
 				return 50;
+			}
+			this.LifeTime = function(skillLv, charaDataManger) {
+				return 60000;
 			}
 		};
 		this.dataArray[skillId] = skillData;

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -225,6 +225,10 @@ function CSkillManager() {
 		return this.dataArray[skillId].CostFixed(skillLv, charaDataManger);
 	}
 
+	this.GetCostAP = function(skillId, skillLv, charaDataManger) {
+		return this.dataArray[skillId].CostAP(skillLv, charaDataManger);
+	}
+
 	this.GetCastTimeVary = function(skillId, skillLv, charaDataManger) {
 		return this.dataArray[skillId].CastTimeVary(skillLv, charaDataManger);
 	}
@@ -31828,6 +31832,12 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE;
 			this.range = CSkillData.RANGE_SHORT;
 			this.element = CSkillData.ELEMENT_VOID;
+			this.CostFixed = function(skillLv, charaDataManger) {
+				return 350;
+			}
+			this.CostAP = function(skillLv, charaDataManger) {
+				return 50;
+			}
 		};
 		this.dataArray[skillId] = skillData;
 		skillId++;

--- a/roro/m/js/castsim.js
+++ b/roro/m/js/castsim.js
@@ -161,6 +161,15 @@ function BuildUpCastSimSimulateArea(objRoot, bAsExpand) {
 
 
 
+	// 持続時間の欄を生成
+	objTd = document.createElement("td");
+	objTd.setAttribute("rowspan", 2);
+	objTr.appendChild(objTd);
+	objText = document.createTextNode("持続時間");
+	objTd.appendChild(objText);
+
+
+
 	// シミュレートの欄を生成
 	objTd = document.createElement("td");
 	objTd.setAttribute("rowspan", 2);
@@ -490,6 +499,14 @@ function BuildUpCastSimSimulateArea(objRoot, bAsExpand) {
 		objTd.setAttribute("align", "right");
 		objTr.appendChild(objTd);
 
+		
+		
+		// 持続時間の欄を生成
+		objTd = document.createElement("td");
+		objTd.setAttribute("id", "OBJID_TD_CAST_SIM_LIFETIME_" + rowidx);
+		objTd.setAttribute("align", "right");
+		objTr.appendChild(objTd);
+
 
 
 		// シミュレートの欄を生成
@@ -642,6 +659,8 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 	var castTime = 0;
 	var delayTime = 0;
 
+	var lifeTimeVal = 0;
+
 	var objTd = null;
 	var objText = null;
 	var objSelect = null;
@@ -682,7 +701,8 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 		costAPVal = 0;
 		castTime = 0;
 		delayTime = 0;
-
+		lifeTimeVal = 0;
+		
 
 
 		// 消費ＳＰの欄を生成
@@ -811,6 +831,21 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 			timeStr = "不明";
 		}
 
+		objText = document.createTextNode(timeStr);
+		objTd.appendChild(objText);
+
+		
+		
+		// 持続時間の欄を生成
+		objTd = document.getElementById("OBJID_TD_CAST_SIM_LIFETIME_" + rowidx);
+		HtmlRemoveAllChild(objTd);
+		lifeTimeVal = g_skillManager.GetLifeTime(skillId, skillLv, null);
+		if (lifeTimeVal >= 0) {
+			timeStr = SprintfTimeStrCastSim(lifeTimeVal);
+		}
+		else {
+			timeStr = "不明";
+		}
 		objText = document.createTextNode(timeStr);
 		objTd.appendChild(objText);
 

--- a/roro/m/js/castsim.js
+++ b/roro/m/js/castsim.js
@@ -127,7 +127,16 @@ function BuildUpCastSimSimulateArea(objRoot, bAsExpand) {
 	objTd = document.createElement("td");
 	objTd.setAttribute("rowspan", 2);
 	objTr.appendChild(objTd);
-	objText = document.createTextNode("消費");
+	objText = document.createTextNode("消費SP");
+	objTd.appendChild(objText);
+
+
+
+	// 消費ＡＰの欄を生成
+	objTd = document.createElement("td");
+	objTd.setAttribute("rowspan", 2);
+	objTr.appendChild(objTd);
+	objText = document.createTextNode("消費AP");
 	objTd.appendChild(objText);
 
 
@@ -625,6 +634,7 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 	var maxLv = 0;
 	var skillLv = 0;
 	var costVal = 0;
+	var costAPVal = 0;
 	var timeVal = 0;
 	var timeStr = "";
 	var paramStr = "";
@@ -669,6 +679,7 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 
 
 		costVal = 0;
+		costAPVal = 0;
 		castTime = 0;
 		delayTime = 0;
 
@@ -683,6 +694,15 @@ function RefreshCastSimSimulateArea(bRefreshLevelSelect) {
 		costVal = Math.max(1, Math.ceil(costVal * GetCostScalingOfSkill(skillId)) / 100);	// %増減
 		costVal = Math.max(1, Math.ceil(costVal * n_tok[ITEM_SP_COST_DOWN] / 100));		// 端数は切り上げ
 		objText = document.createTextNode(costVal);
+		objTd.appendChild(objText);
+
+
+
+		// 消費ＡＰの欄を生成
+		objTd = document.getElementById("OBJID_TD_CAST_SIM_COSTAP_" + rowidx);
+		HtmlRemoveAllChild(objTd);
+		costAPVal = g_skillManager.GetCostAP(skillId, skillLv, null);
+		objText = document.createTextNode(costAPVal);
 		objTd.appendChild(objText);
 
 


### PR DESCRIPTION
・詠唱シミュレータに消費APの表示を追加。
・「消費」→「消費SP」に表記を修正。
・ゲイルストームの消費SPを修正。