### PR TITLE
Firefox 133.0 系で確認された BigInt 誤変換問題へのパッチ提案

### DIFF
--- a/ro4/m/js/CSaveDataUnit.js
+++ b/ro4/m/js/CSaveDataUnit.js
@@ -2347,7 +2347,7 @@ class CSaveDataUnitBase {
 
 		// すべてのプロパティを処理する
 		const propNames = this.constructor.propNames;
-		let readFlag = (1n << BigInt(propNames.length)) - 1n;
+		let readFlag = (1n << toSafeBigInt(propNames.length)) - 1n;
 		for (let idx = 0; idx < propNames.length; readFlag >>= 1n, idx++) {
 
 			// 処理プロパティ名を取得
@@ -2419,7 +2419,7 @@ class CSaveDataUnitBase {
 			const prevNum = CSaveDataConverter.ConvertStoNMIG(prevChar);
 
 			// 残り部分のみ取得
-			prevValue = (prevNum >> BigInt(bitOffset % this.letterBits)) & ((1n << BigInt(spliceBits)) - 1n);
+			prevValue = (prevNum >> toSafeBigInt(bitOffset % this.letterBits)) & ((1n << toSafeBigInt(spliceBits)) - 1n);
 		}
 
 		// コア部分
@@ -2443,12 +2443,12 @@ class CSaveDataUnitBase {
 			const extraNum = CSaveDataConverter.ConvertStoNMIG(extraChar);
 
 			// はみ出し部分のみ取得
-			extraValue = extraNum & ((1n << BigInt(extraBits)) - 1n);
+			extraValue = extraNum & ((1n << toSafeBigInt(extraBits)) - 1n);
 		}
 
 
 		// 最終的な値を合成
-		const propValue = extraValue + (coreValue << BigInt(extraBits)) + (prevValue << BigInt(extraBits + coreBits));
+		const propValue = extraValue + (coreValue << toSafeBigInt(extraBits)) + (prevValue << toSafeBigInt(extraBits + coreBits));
 
 		// マップへ保存
 		this.parsedMap.add(propName, propValue);
@@ -2478,7 +2478,7 @@ class CSaveDataUnitBase {
 	 * @param {int} value プロパティの値
 	 */
 	setProp (propName, value) {
-		this.parsedMap.set(propName, BigInt(value));
+		this.parsedMap.set(propName, toSafeBigInt(value));
 	}
 
 
@@ -2506,7 +2506,7 @@ class CSaveDataUnitBase {
 		const propNames = this.constructor.propNames;
 
 		// すべてのプロパティを処理する
-		let ctrlFlag = (1n << BigInt(propNames.length)) - 1n;
+		let ctrlFlag = (1n << toSafeBigInt(propNames.length)) - 1n;
 		const propNameCountMap = new Map();		// propName ごとの読み取り回数マップ
 		for (let idx = 0; idx < propNames.length; ctrlFlag >>= 1n, idx++) {
 
@@ -2580,7 +2580,7 @@ class CSaveDataUnitBase {
 	appendToDataText (dataTextWork, bitOffset, propValue, propBits) {
 
 		// BitIntにキャストしておく
-		propValue = BigInt(propValue);
+		propValue = toSafeBigInt(propValue);
 
 		// 前側の残り領域、前側切り出し領域、コア領域、後ろ側のはみ出し領域の大きさを計算
 		const prevBits = (this.letterBits - (bitOffset % this.letterBits)) % this.letterBits;
@@ -2597,7 +2597,7 @@ class CSaveDataUnitBase {
 
 			// 入れ込む値を計算
 			const shiftBits = propBits - spliceBits;
-			const shiftedNum = floorBigInt32(propValue >> BigInt(shiftBits));
+			const shiftedNum = floorBigInt32(propValue >> toSafeBigInt(shiftBits));
 
 			// 前側の値を合成し文字表現へ変換
 			const mixedNum = prevNum + (shiftedNum << (this.letterBits - prevBits));
@@ -2611,7 +2611,7 @@ class CSaveDataUnitBase {
 		if (coreBits != 0) {
 
 			// 該当部分の数値を文字列へ変換
-			const coreValue = (propValue >> BigInt(extraBits)) & ((1n << BigInt(coreBits)) - 1n);
+			const coreValue = (propValue >> toSafeBigInt(extraBits)) & ((1n << toSafeBigInt(coreBits)) - 1n);
 			const coreCharCount = coreBits / this.letterBits;
 			const coreText = CSaveDataConverter.ConvertNtoSMIG(coreValue, coreCharCount);
 
@@ -2623,7 +2623,7 @@ class CSaveDataUnitBase {
 		if (extraBits != 0) {
 
 			// 該当部分の数値を文字列へ変換
-			const extraValue = propValue & ((1n << BigInt(extraBits)) - 1n);
+			const extraValue = propValue & ((1n << toSafeBigInt(extraBits)) - 1n);
 			const extraText = CSaveDataConverter.ConvertNtoSMIG(extraValue, 1);
 
 			// クエリ文字列へ追記
@@ -2754,7 +2754,7 @@ class CSaveDataUnitBase {
 
 					// 値が 0 より大きければ有効とみなす
 					if (propValue[idxVal] > 0n) {
-						ctrlFlag |= (1n << BigInt(idxCompaction));
+						ctrlFlag |= (1n << toSafeBigInt(idxCompaction));
 					}
 
 					idxCompaction++;
@@ -2775,9 +2775,9 @@ class CSaveDataUnitBase {
 		if (asDataArray[0].length > 0) {
 			ctrlFlag = 0n;
 			for (let idx = 0; idx < asDataArray[0].length; idx++) {
-				ctrlFlag |= (asDataArray[0][idx] > 0n) ? (1n << BigInt(3 * idx)) : 0n;
-				ctrlFlag |= (asDataArray[1][idx] > 0n) ? (2n << BigInt(3 * idx)) : 0n;
-				ctrlFlag |= (asDataArray[2][idx] > 0n) ? (4n << BigInt(3 * idx)) : 0n;
+				ctrlFlag |= (asDataArray[0][idx] > 0n) ? (1n << toSafeBigInt(3 * idx)) : 0n;
+				ctrlFlag |= (asDataArray[1][idx] > 0n) ? (2n << toSafeBigInt(3 * idx)) : 0n;
+				ctrlFlag |= (asDataArray[2][idx] > 0n) ? (4n << toSafeBigInt(3 * idx)) : 0n;
 			}
 		}
 
@@ -3092,7 +3092,7 @@ const SAVE_DATA_UNIT_TYPE_EQUIPABLE = CSaveDataUnitTypeManager.register(
 				}
 				let oldItemID = this.parsedMap.get(CSaveDataConst.propNameItemID);
 				if (oldItemID <= 5170) {
-					let newItemID = BigInt(CSaveDataUnitEquipable.deprecatedItemIdChangeArray[oldItemID]);
+					let newItemID = toSafeBigInt(CSaveDataUnitEquipable.deprecatedItemIdChangeArray[oldItemID]);
 					if (newItemID != 0n) {
 						this.parsedMap.set(CSaveDataConst.propNameItemID, newItemID);		// 廃止された超越アイテムを置き換え
 						this.parsedMap.set(CSaveDataConst.propNameTranscendenceCount, 1);	// 超越段階を 0 → 1 へ変更

--- a/roro/common/js/util.js
+++ b/roro/common/js/util.js
@@ -1181,7 +1181,7 @@ function floorBigInt32 (value) {
 		// 処理なし
 	}
 
-	return parseInt(BigInt.asUintN(32, BigInt(value)), 10);
+	return parseInt(BigInt.asUintN(32, toSafeBigInt(value)), 10);
 }
 
 /**
@@ -1209,5 +1209,32 @@ function floorBigInt40 (value) {
 		// 処理なし
 	}
 
-	return parseInt(BigInt.asUintN(40, BigInt(value)), 10);
+	return parseInt(BigInt.asUintN(40, toSafeBigInt(value)), 10);
 }
+
+/**
+ * ネイティブの BigInt() をラップしただけのガード関数
+ * FireFox 133.0 系で発現した BigInt() の値変換バグへの対応として追加
+ * 実質的に何もしていませんが BigInt() を呼ぶ前にブレークポイントでワンテンポ待つと事象が抑えられるため
+ * 本関数が同様の効果を発揮して状況が緩和される可能性があります
+ * 問題が再現する場合は例外処理でカバーする方針です
+ * @param {*} value 
+ * @returns 
+ */
+function toSafeBigInt(value) {
+	try {
+	  // 入力値を BigInt に変換
+	  const result = BigInt(value);
+	  
+	  // 入力値と結果の一致を確認（文字列化して比較）
+	  if (value.toString() !== result.toString()) {
+		console.error(`値が一致しません: 入力(${value}) -> 変換後(${result})`);
+	  }
+	  
+	  return result;
+	} catch (error) {
+	  // 例外処理（エラー発生時のログや代替処理）
+	  console.error(`BigInt変換エラー: ${error.message}`);
+	  return null; // 必要に応じて別の値を返す
+	}
+  }

--- a/roro/m/js/CGlobalConstManager.js
+++ b/roro/m/js/CGlobalConstManager.js
@@ -448,7 +448,7 @@ CGlobalConstManager.DefineEnumSubCommon = function (mode, enumName, nameArray, f
 			// 増加値が未指定の場合は、0 とみなす
 			// BigIntが渡される可能性があるので条件判定
 			if (typeof firstValue === "bigint") {
-				value = firstValue + ((stepValue != undefined) ? stepValue : 0n) * BigInt(idx);
+				value = firstValue + ((stepValue != undefined) ? stepValue : 0n) * toSafeBigInt(idx);
 			}
 			else {
 				value = firstValue + ((stepValue != undefined) ? stepValue : 0) * idx;

--- a/roro/m/js/CSaveDataConverter.js
+++ b/roro/m/js/CSaveDataConverter.js
@@ -48,9 +48,9 @@ CSaveDataConverter.ConvertNtoS = function (value, convlen) {
 
 	var lengthDiff = 0;
 
-	digitUnit = BigInt(CSaveDataConverter.LetterMappingArray.length);
+	digitUnit = toSafeBigInt(CSaveDataConverter.LetterMappingArray.length);
 
-	valueWork = BigInt(value);
+	valueWork = toSafeBigInt(value);
 
 	while (valueWork > 0n) {
 
@@ -78,9 +78,9 @@ CSaveDataConverter.ConvertNtoS = function (value, convlen) {
  */
 CSaveDataConverter.ConvertNtoSMIG = function (value, convlen) {
 
-	const digitUnit = BigInt(CSaveDataConverter.LetterMappingArrayMIG.length);
+	const digitUnit = toSafeBigInt(CSaveDataConverter.LetterMappingArrayMIG.length);
 
-	let valueWork = BigInt(value);
+	let valueWork = toSafeBigInt(value);
 	let converted = "";
 
 	while (valueWork > 0n) {
@@ -142,7 +142,7 @@ CSaveDataConverter.ConvertStoN = function (str) {
 CSaveDataConverter.ConvertStoNMIG = function (str) {
 
 	const strWork = "" + str;
-	const digitUnit = BigInt(CSaveDataConverter.LetterMappingArrayMIG.length);
+	const digitUnit = toSafeBigInt(CSaveDataConverter.LetterMappingArrayMIG.length);
 
 	let converted = 0n;
 
@@ -153,7 +153,7 @@ CSaveDataConverter.ConvertStoNMIG = function (str) {
 			continue;
 		}
 
-		converted += (digitUnit ** BigInt(strWork.length - 1 - pos)) * BigInt(valueDigit);
+		converted += (digitUnit ** toSafeBigInt(strWork.length - 1 - pos)) * toSafeBigInt(valueDigit);
 	}
 
 	return converted;

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30469,7 +30469,7 @@ function CheckSpDefRefineOver(spDefRemain, eqpRefined) {
  */
 function CheckSpDefTransendenceOver(spDefRemain, eqpTranscendence) {
 	// 超越条件が指定されている場合
-	baseFlag = BigInt(ITEM_SP_TRANSCENDENCE_1);
+	baseFlag = toSafeBigInt(ITEM_SP_TRANSCENDENCE_1);
 	if (spDefRemain >= baseFlag) {
 		// BigInt の場合、小数点以下が自動的に切り捨てられる
 		requireTranscendence = parseInt(spDefRemain / baseFlag);

--- a/roro/m/js/item.h.js
+++ b/roro/m/js/item.h.js
@@ -1744,7 +1744,7 @@ function GetItemExplainText(spId, spValue) {
 
 	// 『超越段階が◯以上のとき』条件
 	let transcendenceOver = 0;
-	let baseFlag = BigInt(ITEM_SP_TRANSCENDENCE_1);
+	let baseFlag = toSafeBigInt(ITEM_SP_TRANSCENDENCE_1);
 	if (spId >= baseFlag) {
 		// BigInt の場合、小数点以下は自動的に切り捨てられる
 		transcendenceOver = spId / baseFlag;


### PR DESCRIPTION
- #720

Firefox 133.0 系の組み込み BigInt 関数を特定の条件下で用いると
引数として与えられた数を全く異なる数に変換してしまう事象を確認しました

この挙動を見るにブラウザ側で改修すべき不具合だと考えていますが
BigInt関数を呼ぶ前にワンクッション挟んであげることで問題が緩和されることが確認できましたので
本パッチを適用したいと思います

提供していただいた以下のセーブデータで症状が緩和されることを確認しています

https://roratorio-hub.github.io/ratorio/ro4/m/calcx.html?cx1cy1BB4rhrjOxqe01g3MAA00cz21001_j6VqOmujKjtG8Dtd7cz22001VjiF1sD8iKxgwncz23001_jsyiMwVcYCOlXeGx5cz24001-h7et86vx9_t3jvcz25001-hd5pgjbAwDc8Ulcz26001xjhG0gd3id1cz27001VjqMh7yED2BhVmcz28001_jlCG9AhdYy3wT4j27cz29001_9WdIosaloA8_t8Arcz2a001_hhuGX0BKx2jKx5_rcz2b.4ho1cz2c.4hpacz2d00u0jpgsW0jJ12cz2e00u0hph-2z20bcz2f0060hpf-22cz2g00u0hpi-2y231cz2h0060jpjsW02cz2i00u0hpk-2z331cA1Z_1127456b89a3cA128c0cA1vgfdejgh2cB1.m4uxo.8kBm3fj1cC1.94.44cD1.fo029aacH1.4805cL1.6j2n7cR200pG1y7cW100tFJ2011011cZ121

