### PR TITLE
デスバウンド、破砕柱の計算がクラッシュする問題を修正しました

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -14715,21 +14715,21 @@ function BattleHiDam(charaData, specData, mobData, attackMethodConfArray, objCel
 		name64 += "<BR><Font color=Blue><B>反射ダメージ</B></Font>";
 	}
 
-	if(n_A_ActiveSkill==441){
-		if(n_DEATH_BOUND[3]==0){
+	// 「デスバウンド」、「破砕柱」専用の情報オブジェクト
+	let battleCalcInfo = new CBattleCalcInfo();
+	battleCalcInfo.skillId = n_A_ActiveSkill;
+	battleCalcInfo.skillLv = n_A_ActiveSkillLV;	
 
+	if(n_A_ActiveSkill == SKILL_ID_DEATH_BOUND){
+		if(n_DEATH_BOUND[3]==0){
 			var wRef_DB;
 			wRef_DB = (500 + 100 * n_A_ActiveSkillLV) * w_sp_rs;
-
 			// 特定の戦闘エリアでの補正
 			switch (n_B_TAISEI[MOB_CONF_PLAYER_ID_SENTO_AREA]) {
-
-			case MOB_CONF_PLAYER_ID_SENTO_AREA_YE_COLOSSEUM:
-				wRef_DB = (75 + 5 * n_A_ActiveSkillLV) * w_sp_rs;
-				break;
-
+				case MOB_CONF_PLAYER_ID_SENTO_AREA_YE_COLOSSEUM:
+					wRef_DB = (75 + 5 * n_A_ActiveSkillLV) * w_sp_rs;
+					break;
 			}
-
 			var wRef4 = new Array();
 			n_DEATH_BOUND[0] = Math.floor((w_HiDam[0] * 0.7) * wRef_DB / 100);
 			n_DEATH_BOUND[1] = Math.floor((wBHD * 0.7) * wRef_DB / 100);
@@ -14742,7 +14742,7 @@ function BattleHiDam(charaData, specData, mobData, attackMethodConfArray, objCel
 			w_HiDam[6] = Math.floor((w_HiDam[6] * 0.3) * wRef_DB / 100);
 		}
 	}
-	if(n_A_ActiveSkill==630){
+	if(n_A_ActiveSkill == SKILL_ID_HASAICHU){
 		if(n_DEATH_BOUND[3]==0){
 			var wRef_DB;
 			wRef_DB = (100 + 20 * n_A_ActiveSkillLV) * w_sp_rs;


### PR DESCRIPTION
- #880
- #78

避難所の安定版では BattleCalc999() の仮引数に battleCalcInfo が含まれていません
避難所の次世代版で仮引数に battleCalcInfo が追加されました
その際に BattleHiDam() の内部にあるデスバウンドと破砕柱の計算がメンテされなかった
という経緯のようです

今回 BattleHiDam() の内部で空の battleCalcInfo を定義することで問題が改善されましたが
「とりあえずクラッシュしなければいい」という場当たり的な対応です
将来的に追加の対応が必要になるかもしれません

この問題は #848 で新たに発生したものではないので通常の優先度でマージします