### PR TITLE
n次職支援設定のリファクタリング

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -120,6 +120,7 @@
 	<script type="text/javascript" src="js/CCharaConfNizi.js"></script>
 	<script type="text/javascript" src="js/CCharaConfSanzi.js"></script>
 	<script type="text/javascript" src="js/CCharaConfYozi.js"></script>
+	<script type="text/javascript" src="js/CCharaConfDebuff.js"></script>
 	<script type="text/javascript" src="js/CCharaConfCustomStatus.js"></script>
 	<script type="text/javascript" src="js/CCharaConfCustomAtk.js"></script>
 	<script type="text/javascript" src="js/CCharaConfCustomDef.js"></script>
@@ -1371,6 +1372,15 @@
 					<tbody>
 						<tr>
 							<td id="OBJID_TD_CHARA_CONF_YOZI">
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<!-- デバフ -->
+				<table>
+					<tbody>
+						<tr>
+							<td id="OBJID_TD_CHARA_CONF_DEBUFF">
 							</td>
 						</tr>
 					</tbody>

--- a/ro4/m/js/global.js
+++ b/ro4/m/js/global.js
@@ -12,6 +12,9 @@ let g_confDataSanzi = null;
 /** 四次職支援　設定値配列 */
 let g_confDataYozi = null;
 
+/** デバフ 設定値配列 */
+let g_confDataDebuff = null;
+
 /** 一次職支援　設定欄オブジェクト */
 let g_objCharaConfIchizi = null;
 
@@ -23,6 +26,9 @@ let g_objCharaConfSanzi = null;
 
 /** 四次職支援　設定欄オブジェクト */
 let g_objCharaConfYozi = null;
+
+/** デバフ　設定欄オブジェクト */
+let g_objCharaConfDebuff = null;
 
 /** 時限効果設定　設定数 */
 const TIME_ITEM_CONF_COUNT = 20;

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -9074,11 +9074,6 @@ function GetBattlerAtkPercentUp(charaData, specData, mobData, attackMethodConfAr
 	// ギルドスキルＡＴＫ＋１００％
 	if(n_A_PassSkill4[8]) w += 100;
 
-	// 「一次職支援　マーダラーボーナス」
-	if(g_confDataIchizi[CCharaConfIchizi.CONF_ID_MARDERER_BONUS]) {
-		w += 10;
-	}
-
 	// ＡＴＫ％ＵＰ
 	if(GetEquippedTotalSPEquip(87)) w += GetEquippedTotalSPEquip(87);
 

--- a/roro/m/js/CCharaConfDebuff.js
+++ b/roro/m/js/CCharaConfDebuff.js
@@ -1,0 +1,236 @@
+"use strict"
+class CCharaConfDebuff extends CConfBase {
+	constructor(confArray) {
+		// 親クラスのコンストラクタ呼び出し
+		super(confArray);
+		// 設定の限界値
+		// この数を超える場合は、セーブデータの拡張が必要
+		this.confCountLimit = 90;
+		// 設定欄の横方向項目数
+		this.itemInRow = 3;
+		// 設定欄のラベル
+		this.confLabel = "プレイヤー状態異常設定";
+
+		/**  */
+		let confId = 0;
+		let confData = [];
+		let confDataOBJSorted = [];
+
+		/**
+		 * まずは与ダメに影響する状態異常を実装する方針です
+		 */
+		CCharaConfDebuff.CONF_ID_DONTFORGETME = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("私を忘れないで…"),	// ASPD 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(10)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_GLOOMYDAY = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("メランコリー"),	// ASPD 減少, 固定詠唱 増加
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_SATURDAY_NIGHT_FEVER = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("狂乱"),	// HIT 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_MELODYOFSINK = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("メロディーオブシンク"),	// INT 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+		
+		CCharaConfDebuff.CONF_ID_BEYOND_OF_WARCRY = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("ビヨンドオブウォークライ"),	// STR 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+		
+		CCharaConfDebuff.CONF_ID_HARMONIZE = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("ハーモナイズ"),	// 全基本ステータス 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_DECAGI = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("速度減少"),	// AGI 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(10)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_CURSE = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("呪い"),	// ATK 減少, LUK 0
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_DARKNESS = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("暗黒"),	// HIT 減少
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_SLOW_CAST = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("スローキャスト"),	// 変動詠唱 増加
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_FREEZING = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("氷結"),	// ASPD 減少, 固定詠唱 増加
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_MANDRAGORA = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("精神衝撃"),	// INT 減少, 固定詠唱 増加
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_NUMBER),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(5)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_LETHARGY = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("無気力"),	// CRI 0
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_UNLUCKY = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("不幸"),	// HIT 0, スキル失敗率 25%
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+		CCharaConfDebuff.CONF_ID_ALL_STATUS_DOWN = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("オールステータスダウン"),	// 全基本ステータス -100
+			CConfBase.ConfControlType(CONTROL_TYPE_CHECKBOX),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(0),
+			CConfBase.ConfMaxValue(1)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+
+		//----------------------------------------------------------------
+		// 設定変数配列を初期化
+		//----------------------------------------------------------------
+		for (let idx = 0; idx < this.confCountLimit; idx++) {
+			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
+			} else {
+				this.confArray[idx] = 0;
+			}
+		}
+
+		//----------------------------------------------------------------
+		// 表示順序に従い、設定データ定義を再配列
+		//----------------------------------------------------------------
+		confDataOBJSorted = [];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DONTFORGETME];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_GLOOMYDAY];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_SATURDAY_NIGHT_FEVER];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_MELODYOFSINK];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_BEYOND_OF_WARCRY];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_HARMONIZE];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DECAGI];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_CURSE];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DARKNESS];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_SLOW_CAST];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_FREEZING];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_MANDRAGORA];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_LETHARGY];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_UNLUCKY];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_ALL_STATUS_DOWN];
+		this.confDataObj = confDataOBJSorted;
+	}
+
+}

--- a/roro/m/js/CCharaConfDebuff.js
+++ b/roro/m/js/CCharaConfDebuff.js
@@ -204,7 +204,7 @@ class CCharaConfDebuff extends CConfBase {
 		// 設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+			if (this.confDataObj[idx] !== undefined) {
 				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
@@ -214,23 +214,24 @@ class CCharaConfDebuff extends CConfBase {
 		//----------------------------------------------------------------
 		// 表示順序に従い、設定データ定義を再配列
 		//----------------------------------------------------------------
-		confDataOBJSorted = [];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DONTFORGETME];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_GLOOMYDAY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_SATURDAY_NIGHT_FEVER];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_MELODYOFSINK];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_BEYOND_OF_WARCRY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_HARMONIZE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DECAGI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_CURSE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_DARKNESS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_SLOW_CAST];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_FREEZING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_MANDRAGORA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_LETHARGY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_UNLUCKY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfDebuff.CONF_ID_ALL_STATUS_DOWN];
-		this.confDataObj = confDataOBJSorted;
+		const displayOrder = [
+			CCharaConfDebuff.CONF_ID_DONTFORGETME,
+			CCharaConfDebuff.CONF_ID_GLOOMYDAY,
+			CCharaConfDebuff.CONF_ID_SATURDAY_NIGHT_FEVER,
+			CCharaConfDebuff.CONF_ID_MELODYOFSINK,
+			CCharaConfDebuff.CONF_ID_BEYOND_OF_WARCRY,
+			CCharaConfDebuff.CONF_ID_HARMONIZE,
+			CCharaConfDebuff.CONF_ID_DECAGI,
+			CCharaConfDebuff.CONF_ID_CURSE,
+			CCharaConfDebuff.CONF_ID_DARKNESS,
+			CCharaConfDebuff.CONF_ID_SLOW_CAST,
+			CCharaConfDebuff.CONF_ID_FREEZING,
+			CCharaConfDebuff.CONF_ID_MANDRAGORA,
+			CCharaConfDebuff.CONF_ID_LETHARGY,
+			CCharaConfDebuff.CONF_ID_UNLUCKY,
+			CCharaConfDebuff.CONF_ID_ALL_STATUS_DOWN,
+		];
+		this.confDataObj = displayOrder.map(id => this.confDataObj[id]);
 	}
 
 }

--- a/roro/m/js/CCharaConfIchizi.js
+++ b/roro/m/js/CCharaConfIchizi.js
@@ -1,40 +1,15 @@
 function CCharaConfIchizi(confArray) {
-
 	// 継承定義
 	CCharaConfIchizi.prototype = new CConfBase();
-
-
-
 	// 基底クラスのコンストラクタ呼び出し
 	CConfBase.call(this, confArray);
-
-
-
 	// 設定の限界値
 	// この数を超える場合は、セーブデータの拡張が必要
 	this.confCountLimit = 50;
-
-
-
 	// 設定欄の横方向項目数
 	this.itemInRow = 2;
-
-
-
 	// 設定欄のラベル
 	this.confLabel = "一次職支援設定";
-
-
-
-
-
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
-	//****
-	//**** 一次職支援データ定義
-	//****
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
 
 	/**
 	 * 設定データを初期化（セットアップ）する.
@@ -211,13 +186,14 @@ function CCharaConfIchizi(confArray) {
 
 
 		//----------------------------------------------------------------
-		// 一次職支援設定変数配列を初期化
+		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
-		for (idx = 0; idx < this.confCountLimit; idx++) {
+		for (let idx = 0; idx < this.confCountLimit; idx++) {
 			if (idx < this.confDataObj.length) {
-				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-			}
-			else {
+				if (this.confDataObj[idx] !== undefined) {
+					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
+				}
+			} else {
 				this.confArray[idx] = 0;
 			}
 		}
@@ -245,10 +221,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj = confDataOBJSorted;
 
 	}
-
-
-
-
 
 	/**
 	 * 設定欄テーブルを構築する（サブ　特殊欄構築用）.
@@ -285,13 +257,6 @@ function CCharaConfIchizi(confArray) {
 		}
 	}
 
-
-
-
-
 	// 初期化実行
 	this.InitData();
-
-
-
 }

--- a/roro/m/js/CCharaConfIchizi.js
+++ b/roro/m/js/CCharaConfIchizi.js
@@ -148,7 +148,7 @@ function CCharaConfIchizi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+			if (this.confDataObj[idx] !== undefined) {
 				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
@@ -158,21 +158,22 @@ function CCharaConfIchizi(confArray) {
 		//----------------------------------------------------------------
 		// 表示順序に従い、一次職支援設定データ定義を再配列
 		//----------------------------------------------------------------
-		confDataOBJSorted = new Array();
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_BLESSING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_SOKUDO_ZOKA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_ANGELUS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_SHIEN_PROVOKE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_MAGNUM_BREAK_ZYOTAI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_ENDURE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_SHUCHURYOKU_KOZYO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_LOUD_VOICE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		this.confDataObj = confDataOBJSorted;
+		const displayOrder = [
+			CCharaConfIchizi.CONF_ID_BLESSING,
+			CCharaConfIchizi.CONF_ID_SOKUDO_ZOKA,
+			CCharaConfIchizi.CONF_ID_ANGELUS,
+			CCharaConfIchizi.CONF_ID_DUMMY,
+			CCharaConfIchizi.CONF_ID_SHIEN_PROVOKE,
+			CCharaConfIchizi.CONF_ID_MAGNUM_BREAK_ZYOTAI,
+			CCharaConfIchizi.CONF_ID_ENDURE,
+			CCharaConfIchizi.CONF_ID_DUMMY,
+			CCharaConfIchizi.CONF_ID_SHUCHURYOKU_KOZYO,
+			CCharaConfIchizi.CONF_ID_DUMMY,
+			CCharaConfIchizi.CONF_ID_LOUD_VOICE,
+			CCharaConfIchizi.CONF_ID_DUMMY,
+			CCharaConfIchizi.CONF_ID_DUMMY,
+		];
+		this.confDataObj = displayOrder.map(id => this.confDataObj[id]);
 	}
 
 	/**

--- a/roro/m/js/CCharaConfIchizi.js
+++ b/roro/m/js/CCharaConfIchizi.js
@@ -16,19 +16,11 @@ function CCharaConfIchizi(confArray) {
 	 * （継承先でオーバーライドすること）
 	 */
 	this.InitData = function () {
-
-		var idx = 0;
-
 		var confId = 0;
 		var confData = new Array();
 		var confDataOBJSorted = new Array();
-
-
-
 		// 基底クラスのセットアップ処理を実行
 		CCharaConfIchizi.prototype.InitData.call(this);
-
-
 
 		//----------------------------------------------------------------
 		// データ定義　ここから
@@ -45,8 +37,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfIchizi.CONF_ID_SOKUDO_ZOKA = confId;
 		confData = [
 			confId,
@@ -58,8 +48,6 @@ function CCharaConfIchizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfIchizi.CONF_ID_ANGELUS = confId;
 		confData = [
@@ -73,8 +61,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfIchizi.CONF_ID_MAGNUM_BREAK_ZYOTAI = confId;
 		confData = [
 			confId,
@@ -86,8 +72,6 @@ function CCharaConfIchizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfIchizi.CONF_ID_SHIEN_PROVOKE = confId;
 		confData = [
@@ -101,21 +85,8 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
-		CCharaConfIchizi.CONF_ID_MARDERER_BONUS = confId;
-		confData = [
-			confId,
-			CConfBase.ConfText("マーダラーボーナス"),
-			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_SPECIAL),
-			CConfBase.ConfDefaultValue(0),
-			CConfBase.ConfMinValue(0),
-			CConfBase.ConfMaxValue(2)
-		];
-		this.confDataObj[confId] = confData;
+		// マーダラーボーナス廃止に伴う欠番
 		confId++;
-
-
 
 		CCharaConfIchizi.CONF_ID_SHUCHURYOKU_KOZYO = confId;
 		confData = [
@@ -129,8 +100,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfIchizi.CONF_ID_LOUD_VOICE = confId;
 		confData = [
 			confId,
@@ -142,8 +111,6 @@ function CCharaConfIchizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfIchizi.CONF_ID_ENDURE = confId;
 		confData = [
@@ -157,10 +124,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
-
-
 		CCharaConfIchizi.CONF_ID_DUMMY = confId;
 		confData = [
 			confId,
@@ -173,8 +136,6 @@ function CCharaConfIchizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		//----------------------------------------------------------------
 		// データ定義数チェック
 		//----------------------------------------------------------------
@@ -182,8 +143,6 @@ function CCharaConfIchizi(confArray) {
 			alert("一次職支援設定　定義数超過");
 			return;
 		}
-
-
 
 		//----------------------------------------------------------------
 		// 支援設定変数配列を初期化
@@ -197,8 +156,6 @@ function CCharaConfIchizi(confArray) {
 				this.confArray[idx] = 0;
 			}
 		}
-
-
 
 		//----------------------------------------------------------------
 		// 表示順序に従い、一次職支援設定データ定義を再配列
@@ -216,10 +173,8 @@ function CCharaConfIchizi(confArray) {
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_LOUD_VOICE];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_MARDERER_BONUS];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfIchizi.CONF_ID_DUMMY];
 		this.confDataObj = confDataOBJSorted;
-
 	}
 
 	/**
@@ -227,33 +182,11 @@ function CCharaConfIchizi(confArray) {
 	 * （継承先でオーバーライドすること）
 	 */
 	this.BuildUpSelectAreaSubForSpecial = function (objTd, confData) {
-
 		var confId = confData[CConfBase.CONF_DATA_INDEX_ID];
 		var controlId = this.GetControlIdString(this.instanceNo, confId);
 		var controlType = confData[CConfBase.CONF_DATA_INDEX_CONTROL_TYPE];
-
 		// 個別に実装する
 		switch (confId) {
-
-
-		// マーダラーボーナス
-		case CCharaConfIchizi.CONF_ID_MARDERER_BONUS:
-
-			// 選択セレクトボックスを生成
-			objSelect = document.createElement("select");
-			objSelect.setAttribute("id", controlId);
-			objSelect.setAttribute("onChange", "CConfBase.OnChangeValueHandler(" + this.instanceNo + ", true)");
-			objTd.appendChild(objSelect);
-
-			// セレクトオプションを生成
-			objOption = HtmlCreateElementOption(0, "なし", objSelect);
-			objOption = HtmlCreateElementOption(1, "ALL+3", objSelect);
-			objOption = HtmlCreateElementOption(2, "ALL+5", objSelect);
-
-			// 初期値設定
-			objSelect.setAttribute("value", confData[CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE]);
-
-			break;
 		}
 	}
 

--- a/roro/m/js/CCharaConfIchizi.js
+++ b/roro/m/js/CCharaConfIchizi.js
@@ -148,10 +148,8 @@ function CCharaConfIchizi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length) {
-				if (this.confDataObj[idx] !== undefined) {
-					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-				}
+			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
 			}

--- a/roro/m/js/CCharaConfNizi.js
+++ b/roro/m/js/CCharaConfNizi.js
@@ -342,10 +342,8 @@ function CCharaConfNizi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length) {
-				if (this.confDataObj[idx] !== undefined) {
-					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-				}
+			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
 			}

--- a/roro/m/js/CCharaConfNizi.js
+++ b/roro/m/js/CCharaConfNizi.js
@@ -1,59 +1,27 @@
 function CCharaConfNizi(confArray) {
-
 	// 継承定義
 	CCharaConfNizi.prototype = new CConfBase();
-
-
-
 	// 基底クラスのコンストラクタ呼び出し
 	CConfBase.call(this, confArray);
-
-
-
 	// 設定の限界値
 	// この数を超える場合は、セーブデータの拡張が必要
 	this.confCountLimit = 50;
-
-
-
 	// 設定欄の横方向項目数
 	this.itemInRow = 2;
-
-
-
 	// 設定欄のラベル
 	this.confLabel = "二次職支援設定";
-
-
-
-
-
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
-	//****
-	//**** 二次職支援データ定義
-	//****
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
 
 	/**
 	 * 設定データを初期化（セットアップ）する.
 	 * （継承先でオーバーライドすること）
 	 */
 	this.InitData = function () {
-
-		var idx = 0;
-
-		var confId = 0;
-		var confData = new Array();
-		var confDataOBJSorted = new Array();
-
-
+		let confId = 0;
+		let confData = new Array();
+		let confDataOBJSorted = new Array();
 
 		// 基底クラスのセットアップ処理を実行
 		CCharaConfNizi.prototype.InitData.call(this);
-
-
 
 		//----------------------------------------------------------------
 		// データ定義　ここから
@@ -74,8 +42,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_ZOKUSEIBA_LEVEL = confId;
 		confData = [
 			confId,
@@ -87,8 +53,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_SHIEN_MIND_BREAKER = confId;
 		confData = [
@@ -102,8 +66,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_SEITAI_KOFUKU = confId;
 		confData = [
 			confId,
@@ -115,8 +77,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_KAITO = confId;
 		confData = [
@@ -130,8 +90,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_IMPOSITIO_MANUS = confId;
 		confData = [
 			confId,
@@ -143,8 +101,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_SUFFRAGIUM = confId;
 		confData = [
@@ -158,8 +114,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_GLORIA = confId;
 		confData = [
 			confId,
@@ -171,8 +125,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_ASSUMPTIO = confId;
 		confData = [
@@ -186,8 +138,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_ADRENALINE_RUSH = confId;
 		confData = [
 			confId,
@@ -199,8 +149,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_WEAPON_PERFECTION = confId;
 		confData = [
@@ -214,8 +162,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_OVER_TRUST = confId;
 		confData = [
 			confId,
@@ -227,8 +173,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_WIND_WALK = confId;
 		confData = [
@@ -242,8 +186,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_KIKO = confId;
 		confData = [
 			confId,
@@ -255,8 +197,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_PROVIDENCE = confId;
 		confData = [
@@ -270,8 +210,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_CONCENTRATION = confId;
 		confData = [
 			confId,
@@ -283,8 +221,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_TRUE_SIGHT = confId;
 		confData = [
@@ -298,8 +234,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_MAHORYOKU_ZOFUKU = confId;
 		confData = [
 			confId,
@@ -311,8 +245,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_DEFENDER = confId;
 		confData = [
@@ -326,8 +258,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_AUTO_GUARD = confId;
 		confData = [
 			confId,
@@ -339,8 +269,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_CLOSE_CONFINE = confId;
 		confData = [
@@ -354,8 +282,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		CCharaConfNizi.CONF_ID_AURA_BLADE = confId;
 		confData = [
 			confId,
@@ -367,8 +293,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
 
 		CCharaConfNizi.CONF_ID_KONGO = confId;
 		confData = [
@@ -382,7 +306,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
 		CCharaConfNizi.CONF_ID_MAXIMIZE_POWER = confId;
 		confData = [
 			confId,
@@ -394,9 +317,6 @@ function CCharaConfNizi(confArray) {
 		];
 		this.confDataObj[confId] = confData;
 		confId++;
-
-
-
 
 		CCharaConfNizi.CONF_ID_DUMMY = confId;
 		confData = [
@@ -410,8 +330,6 @@ function CCharaConfNizi(confArray) {
 		this.confDataObj[confId] = confData;
 		confId++;
 
-
-
 		//----------------------------------------------------------------
 		// データ定義数チェック
 		//----------------------------------------------------------------
@@ -420,21 +338,18 @@ function CCharaConfNizi(confArray) {
 			return;
 		}
 
-
-
 		//----------------------------------------------------------------
-		// 二次職支援設定変数配列を初期化
+		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
-		for (idx = 0; idx < this.confCountLimit; idx++) {
+		for (let idx = 0; idx < this.confCountLimit; idx++) {
 			if (idx < this.confDataObj.length) {
-				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-			}
-			else {
+				if (this.confDataObj[idx] !== undefined) {
+					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
+				}
+			} else {
 				this.confArray[idx] = 0;
 			}
 		}
-
-
 
 		//----------------------------------------------------------------
 		// 表示順序に従い、二次職支援設定データ定義を再配列
@@ -471,12 +386,7 @@ function CCharaConfNizi(confArray) {
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_KAITO];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
 		this.confDataObj = confDataOBJSorted;
-
 	}
-
-
-
-
 
 	/**
 	 * 設定欄テーブルを構築する（サブ　特殊欄構築用）.
@@ -550,13 +460,6 @@ function CCharaConfNizi(confArray) {
 		}
 	}
 
-
-
-
-
 	// 初期化実行
 	this.InitData();
-
-
-
 }

--- a/roro/m/js/CCharaConfNizi.js
+++ b/roro/m/js/CCharaConfNizi.js
@@ -342,7 +342,7 @@ function CCharaConfNizi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+			if (this.confDataObj[idx] !== undefined) {
 				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
@@ -352,38 +352,39 @@ function CCharaConfNizi(confArray) {
 		//----------------------------------------------------------------
 		// 表示順序に従い、二次職支援設定データ定義を再配列
 		//----------------------------------------------------------------
-		confDataOBJSorted = new Array();
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_IMPOSITIO_MANUS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_SUFFRAGIUM];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_GLORIA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_SEITAI_KOFUKU];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_ASSUMPTIO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_ADRENALINE_RUSH];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_OVER_TRUST];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_WEAPON_PERFECTION];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_MAXIMIZE_POWER];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_KIKO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_KONGO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DEFENDER];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_AUTO_GUARD];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_PROVIDENCE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_CLOSE_CONFINE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_AURA_BLADE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_CONCENTRATION];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_WIND_WALK];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_TRUE_SIGHT];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_MAHORYOKU_ZOFUKU];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_ZOKUSEIBA_SHURUI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_ZOKUSEIBA_LEVEL];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_SHIEN_MIND_BREAKER];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_KAITO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfNizi.CONF_ID_DUMMY];
-		this.confDataObj = confDataOBJSorted;
+		const displayOrder = [
+			CCharaConfNizi.CONF_ID_IMPOSITIO_MANUS,
+			CCharaConfNizi.CONF_ID_SUFFRAGIUM,
+			CCharaConfNizi.CONF_ID_GLORIA,
+			CCharaConfNizi.CONF_ID_SEITAI_KOFUKU,
+			CCharaConfNizi.CONF_ID_ASSUMPTIO,
+			CCharaConfNizi.CONF_ID_DUMMY,
+			CCharaConfNizi.CONF_ID_ADRENALINE_RUSH,
+			CCharaConfNizi.CONF_ID_OVER_TRUST,
+			CCharaConfNizi.CONF_ID_WEAPON_PERFECTION,
+			CCharaConfNizi.CONF_ID_MAXIMIZE_POWER,
+			CCharaConfNizi.CONF_ID_KIKO,
+			CCharaConfNizi.CONF_ID_KONGO,
+			CCharaConfNizi.CONF_ID_DEFENDER,
+			CCharaConfNizi.CONF_ID_AUTO_GUARD,
+			CCharaConfNizi.CONF_ID_PROVIDENCE,
+			CCharaConfNizi.CONF_ID_DUMMY,
+			CCharaConfNizi.CONF_ID_CLOSE_CONFINE,
+			CCharaConfNizi.CONF_ID_DUMMY,
+			CCharaConfNizi.CONF_ID_AURA_BLADE,
+			CCharaConfNizi.CONF_ID_CONCENTRATION,
+			CCharaConfNizi.CONF_ID_WIND_WALK,
+			CCharaConfNizi.CONF_ID_TRUE_SIGHT,
+			CCharaConfNizi.CONF_ID_MAHORYOKU_ZOFUKU,
+			CCharaConfNizi.CONF_ID_DUMMY,
+			CCharaConfNizi.CONF_ID_ZOKUSEIBA_SHURUI,
+			CCharaConfNizi.CONF_ID_ZOKUSEIBA_LEVEL,
+			CCharaConfNizi.CONF_ID_SHIEN_MIND_BREAKER,
+			CCharaConfNizi.CONF_ID_DUMMY,
+			CCharaConfNizi.CONF_ID_KAITO,
+			CCharaConfNizi.CONF_ID_DUMMY,
+		];
+		this.confDataObj = displayOrder.map(id => this.confDataObj[id]);
 	}
 
 	/**

--- a/roro/m/js/CCharaConfSanzi.js
+++ b/roro/m/js/CCharaConfSanzi.js
@@ -1,40 +1,15 @@
 function CCharaConfSanzi(confArray) {
-
 	// 継承定義
 	CCharaConfSanzi.prototype = new CConfBase();
-
-
-
 	// 基底クラスのコンストラクタ呼び出し
 	CConfBase.call(this, confArray);
-
-
-
 	// 設定の限界値
 	// この数を超える場合は、セーブデータの拡張が必要
 	this.confCountLimit = 100;
-
-
-
 	// 設定欄の横方向項目数
 	this.itemInRow = 2;
-
-
-
 	// 設定欄のラベル
 	this.confLabel = "三次職支援設定";
-
-
-
-
-
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
-	//****
-	//**** 三次職支援データ定義
-	//****
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
 
 	/**
 	 * 設定データを初期化（セットアップ）する.
@@ -477,13 +452,14 @@ function CCharaConfSanzi(confArray) {
 
 
 		//----------------------------------------------------------------
-		// 三次職支援設定変数配列を初期化
+		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
-		for (idx = 0; idx < this.confCountLimit; idx++) {
+		for (let idx = 0; idx < this.confCountLimit; idx++) {
 			if (idx < this.confDataObj.length) {
-				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-			}
-			else {
+				if (this.confDataObj[idx] !== undefined) {
+					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
+				}
+			} else {
 				this.confArray[idx] = 0;
 			}
 		}
@@ -527,10 +503,6 @@ function CCharaConfSanzi(confArray) {
 		this.confDataObj = confDataOBJSorted;
 
 	}
-
-
-
-
 
 	/**
 	 * 設定欄テーブルを構築する（サブ　特殊欄構築用）.
@@ -608,13 +580,6 @@ function CCharaConfSanzi(confArray) {
 		}
 	}
 
-
-
-
-
 	// 初期化実行
 	this.InitData();
-
-
-
 }

--- a/roro/m/js/CCharaConfSanzi.js
+++ b/roro/m/js/CCharaConfSanzi.js
@@ -455,10 +455,8 @@ function CCharaConfSanzi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length) {
-				if (this.confDataObj[idx] !== undefined) {
-					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-				}
+			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
 			}

--- a/roro/m/js/CCharaConfSanzi.js
+++ b/roro/m/js/CCharaConfSanzi.js
@@ -455,7 +455,7 @@ function CCharaConfSanzi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+			if (this.confDataObj[idx] !== undefined) {
 				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
@@ -467,39 +467,39 @@ function CCharaConfSanzi(confArray) {
 		//----------------------------------------------------------------
 		// 表示順序に従い、三次職支援設定データ定義を再配列
 		//----------------------------------------------------------------
-		confDataOBJSorted = new Array();
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_GIANT_GLOTH];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_FIGHTING_SPIRIT];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_PIETY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_STRIKING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_STRIKINGYO_FUYOSKILL_LEVEL_GOKEI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_EXPIATIO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_ODINNO_CHIKARA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_EPICLESIS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_SECRAMENT];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_LAUDAAGNUS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_LAUDARAMUS];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_UNLIMIT];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_FRIGGNO_UTA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_BUNSHIN];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_TAKANO_TAMASHI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_YOSENO_TAMASHI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_KAGENO_TAMASHI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_GOLEMNO_TAMASHI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_PAIN_KILLER];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_PAIN_KILLER_BASE_LEVEL];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_EBI_ZANMAI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_GROOMING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_EBI_PARTY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_EBI_PARTY_TAMASHI_LEVEL];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_CHATTERING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_ARCLOUSE_DASH];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_KEIKAI];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfSanzi.CONF_ID_DUMMY];
-		this.confDataObj = confDataOBJSorted;
-
+		const displayOrder = [
+			CCharaConfSanzi.CONF_ID_GIANT_GLOTH,
+			CCharaConfSanzi.CONF_ID_FIGHTING_SPIRIT,
+			CCharaConfSanzi.CONF_ID_PIETY,
+			CCharaConfSanzi.CONF_ID_DUMMY,
+			CCharaConfSanzi.CONF_ID_STRIKING,
+			CCharaConfSanzi.CONF_ID_STRIKINGYO_FUYOSKILL_LEVEL_GOKEI,
+			CCharaConfSanzi.CONF_ID_EXPIATIO,
+			CCharaConfSanzi.CONF_ID_ODINNO_CHIKARA,
+			CCharaConfSanzi.CONF_ID_EPICLESIS,
+			CCharaConfSanzi.CONF_ID_SECRAMENT,
+			CCharaConfSanzi.CONF_ID_LAUDAAGNUS,
+			CCharaConfSanzi.CONF_ID_LAUDARAMUS,
+			CCharaConfSanzi.CONF_ID_UNLIMIT,
+			CCharaConfSanzi.CONF_ID_FRIGGNO_UTA,
+			CCharaConfSanzi.CONF_ID_BUNSHIN,
+			CCharaConfSanzi.CONF_ID_DUMMY,
+			CCharaConfSanzi.CONF_ID_TAKANO_TAMASHI,
+			CCharaConfSanzi.CONF_ID_YOSENO_TAMASHI,
+			CCharaConfSanzi.CONF_ID_KAGENO_TAMASHI,
+			CCharaConfSanzi.CONF_ID_GOLEMNO_TAMASHI,
+			CCharaConfSanzi.CONF_ID_PAIN_KILLER,
+			CCharaConfSanzi.CONF_ID_PAIN_KILLER_BASE_LEVEL,
+			CCharaConfSanzi.CONF_ID_EBI_ZANMAI,
+			CCharaConfSanzi.CONF_ID_GROOMING,
+			CCharaConfSanzi.CONF_ID_EBI_PARTY,
+			CCharaConfSanzi.CONF_ID_EBI_PARTY_TAMASHI_LEVEL,
+			CCharaConfSanzi.CONF_ID_CHATTERING,
+			CCharaConfSanzi.CONF_ID_ARCLOUSE_DASH,
+			CCharaConfSanzi.CONF_ID_KEIKAI,
+			CCharaConfSanzi.CONF_ID_DUMMY,
+		];
+		this.confDataObj = displayOrder.map(id => this.confDataObj[id]);
 	}
 
 	/**

--- a/roro/m/js/CCharaConfYozi.js
+++ b/roro/m/js/CCharaConfYozi.js
@@ -301,7 +301,7 @@ function CCharaConfYozi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+			if (this.confDataObj[idx] !== undefined) {
 				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
@@ -313,29 +313,30 @@ function CCharaConfYozi(confArray) {
 		//----------------------------------------------------------------
 		// 表示順序に従い、四次職支援設定データ定義を再配列
 		//----------------------------------------------------------------
-		confDataOBJSorted = new Array();
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_ARUGUTUS_VITA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_ARUGUTUS_TERUM];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_PRESENSE_AKYACE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_CONPETENTIA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_RERIGIO];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_BENEDICTUM];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_CLIMAX_IMPACT];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_SPELL_ENCHANTING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_KOGEKI_SOCHI_YUKOKA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_BOGYO_SOCHI_YUKOKA];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_MUSICAL_INTERLUDE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_YUYAKENO_SERENADE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_PRONTERA_MARCH];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_DUMMY];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_BUSHI_FU];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_HOSHI_FU];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_GOGYO_FU];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_TENCHI_SHINRE];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_NYAN_BRESSING];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_MARIN_FESTIVAL];
-		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfYozi.CONF_ID_SAND_FESTIVAL];
-		this.confDataObj = confDataOBJSorted;
+		const displayOrder = [
+			CCharaConfYozi.CONF_ID_ARUGUTUS_VITA,
+			CCharaConfYozi.CONF_ID_ARUGUTUS_TERUM,
+			CCharaConfYozi.CONF_ID_PRESENSE_AKYACE,
+			CCharaConfYozi.CONF_ID_CONPETENTIA,
+			CCharaConfYozi.CONF_ID_RERIGIO,
+			CCharaConfYozi.CONF_ID_BENEDICTUM,
+			CCharaConfYozi.CONF_ID_CLIMAX_IMPACT,
+			CCharaConfYozi.CONF_ID_SPELL_ENCHANTING,
+			CCharaConfYozi.CONF_ID_KOGEKI_SOCHI_YUKOKA,
+			CCharaConfYozi.CONF_ID_BOGYO_SOCHI_YUKOKA,
+			CCharaConfYozi.CONF_ID_MUSICAL_INTERLUDE,
+			CCharaConfYozi.CONF_ID_YUYAKENO_SERENADE,
+			CCharaConfYozi.CONF_ID_PRONTERA_MARCH,
+			CCharaConfYozi.CONF_ID_DUMMY,
+			CCharaConfYozi.CONF_ID_BUSHI_FU,
+			CCharaConfYozi.CONF_ID_HOSHI_FU,
+			CCharaConfYozi.CONF_ID_GOGYO_FU,
+			CCharaConfYozi.CONF_ID_TENCHI_SHINRE,
+			CCharaConfYozi.CONF_ID_NYAN_BRESSING,
+			CCharaConfYozi.CONF_ID_MARIN_FESTIVAL,
+			CCharaConfYozi.CONF_ID_SAND_FESTIVAL,
+		];
+		this.confDataObj = displayOrder.map(id => this.confDataObj[id]);
 
 	}
 

--- a/roro/m/js/CCharaConfYozi.js
+++ b/roro/m/js/CCharaConfYozi.js
@@ -301,10 +301,8 @@ function CCharaConfYozi(confArray) {
 		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
 		for (let idx = 0; idx < this.confCountLimit; idx++) {
-			if (idx < this.confDataObj.length) {
-				if (this.confDataObj[idx] !== undefined) {
-					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-				}
+			if (idx < this.confDataObj.length && this.confDataObj[idx] !== undefined) {
+				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
 			} else {
 				this.confArray[idx] = 0;
 			}

--- a/roro/m/js/CCharaConfYozi.js
+++ b/roro/m/js/CCharaConfYozi.js
@@ -1,40 +1,15 @@
 function CCharaConfYozi(confArray) {
-
 	// 継承定義
 	CCharaConfYozi.prototype = new CConfBase();
-
-
-
 	// 基底クラスのコンストラクタ呼び出し
 	CConfBase.call(this, confArray);
-
-
-
 	// 設定の限界値
 	// この数を超える場合は、セーブデータの拡張が必要
 	this.confCountLimit = 30;
-
-
-
 	// 設定欄の横方向項目数
 	this.itemInRow = 2;
-
-
-
 	// 設定欄のラベル
 	this.confLabel = "四次職支援設定";
-
-
-
-
-
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
-	//****
-	//**** 四次職支援データ定義
-	//****
-	//********************************************************************************************************************************
-	//********************************************************************************************************************************
 
 	/**
 	 * 設定データを初期化（セットアップ）する.
@@ -323,13 +298,14 @@ function CCharaConfYozi(confArray) {
 
 
 		//----------------------------------------------------------------
-		// 四次職支援設定変数配列を初期化
+		// 支援設定変数配列を初期化
 		//----------------------------------------------------------------
-		for (idx = 0; idx < this.confCountLimit; idx++) {
+		for (let idx = 0; idx < this.confCountLimit; idx++) {
 			if (idx < this.confDataObj.length) {
-				this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
-			}
-			else {
+				if (this.confDataObj[idx] !== undefined) {
+					this.confArray[idx] = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE];
+				}
+			} else {
 				this.confArray[idx] = 0;
 			}
 		}
@@ -365,10 +341,6 @@ function CCharaConfYozi(confArray) {
 
 	}
 
-
-
-
-
 	/**
 	 * 設定欄テーブルを構築する（サブ　特殊欄構築用）.
 	 * （継承先でオーバーライドすること）
@@ -385,13 +357,6 @@ function CCharaConfYozi(confArray) {
 		}
 	}
 
-
-
-
-
 	// 初期化実行
 	this.InitData();
-
-
-
 }

--- a/roro/m/js/CConfBase.js
+++ b/roro/m/js/CConfBase.js
@@ -22,10 +22,6 @@ CGlobalConstManager.DefineEnum(
 	1
 );
 
-
-
-
-
 /**
  * データ管理用クラス.
  */
@@ -37,25 +33,17 @@ function CTargetData(instanceNo, objThis, objRoot, objSwitch, objHeader) {
 	this.objHeader = objHeader;
 }
 
-
-
 /**
  * 設定欄クラス.
  */
 function CConfBase(confArray) {
 
-
-
 	// 設定の限界値
 	// この数を超える場合は、セーブデータの拡張が必要
 	this.confCountLimit = 0;
 
-
-
 	// 設定欄の横方向項目数
 	this.itemInRow = 2;
-
-
 
 	//----------------------------------------------------------------
 	// データインデックス定義
@@ -66,10 +54,6 @@ function CConfBase(confArray) {
 	CConfBase.CONF_DATA_INDEX_DEFAULT_VALUE	= 3;
 	CConfBase.CONF_DATA_INDEX_MIN_VALUE		= 4;
 	CConfBase.CONF_DATA_INDEX_MAX_VALUE		= 5;
-
-
-
-
 
 	// インスタンス番号
 	this.instanceNo = -1;
@@ -86,10 +70,6 @@ function CConfBase(confArray) {
 	// 設定データの配列
 	this.confDataObj = new Array();
 
-
-
-
-
 	//================================================================
 	// データ定義用ダミー関数
 	// （可読性を高める目的で使用する）
@@ -100,28 +80,17 @@ function CConfBase(confArray) {
 	CConfBase.ConfMinValue = function (value) { return value; };
 	CConfBase.ConfMaxValue = function (value) { return value; };
 
-
-
-
-
 	/**
 	 * 設定データを初期化（セットアップ）する.
 	 * （継承先でオーバーライドすること）
 	 */
 	this.InitData = function () {
-
 		// ターゲットオブジェクト情報の配列を用意する
 		if (CConfBase.targetArray == undefined) {
 			CConfBase.targetArray = new Array();
-
 		}
-
 		return;
 	}
-
-
-
-
 
 	/**
 	 * ヘッダ部品のＩＤを取得する.
@@ -144,32 +113,24 @@ function CConfBase(confArray) {
 		return "OBJID_CONTROL_CONF_" + instanceNo + "_ID_" + confId;
 	}
 
-
-
-
-
 	/**
 	 * 設定欄テーブルを構築する.
 	 * @param objRoot テーブルの親オブジェクト
 	 * @param bAsExpand 展開表示フラグ（true : 展開表示、false : ヘッダのみ）
 	 */
 	this.BuildUpSelectArea = function (objRoot, bAsExpand) {
-
 		var instanceNo = 0;
 		var instanceData = null;
-
 		var idx = 0;
 		var confId = 0;
 		var confText = "";
 		var textUnit = "";
 		var textArray = null;
-
 		var controlId = "";
 		var controlType = 0;
 		var controlValue = 0;
 		var controlValueMin = 0;
 		var controlValueMax = 0;
-
 		var objTable = null;
 		var objTbody = null;
 		var objTr = null;
@@ -181,13 +142,9 @@ function CConfBase(confArray) {
 		var objLabel = null;
 		var objA = null;
 
-
-
 		if (!objRoot) {
 			return;
 		}
-
-
 
 		// 既に同一のクラスインスタンスがあるかを検索し、インスタンス番号を決定する
 		instanceNo = CConfBase.targetArray.length;
@@ -197,8 +154,6 @@ function CConfBase(confArray) {
 				break;
 			}
 		}
-
-
 
 		// 引数のルートオブジェクト配下を一度全削除
 		HtmlRemoveAllChild(objRoot);
@@ -211,8 +166,6 @@ function CConfBase(confArray) {
 
 		objTbody = document.createElement("tbody");
 		objTable.appendChild(objTbody);
-
-
 
 		// 設定欄テーブルのヘッダ部分を生成
 		objTr = document.createElement("tr");
@@ -237,14 +190,10 @@ function CConfBase(confArray) {
 		objLabel.setAttribute("for", this.GetSwitchIdString(instanceNo));
 		HtmlCreateTextNode(this.confLabel, objLabel);
 
-
-
 		// インスタンスを登録
 		instanceData = new CTargetData(instanceNo, this, objRoot, objInput, objTd);
 		CConfBase.targetArray[instanceNo] = instanceData;
 		this.instanceNo = instanceNo;
-
-
 
 		// 展開表示でなければ、ヘッダだけ更新して終了
 		if (!bAsExpand) {
@@ -253,8 +202,6 @@ function CConfBase(confArray) {
 
 			return;
 		}
-
-
 
 		// 設定定義をループして、設定欄を構築する
 		for (idx = 0; idx < this.confDataObj.length; idx++) {
@@ -266,12 +213,8 @@ function CConfBase(confArray) {
 				objTbody.appendChild(objTr);
 			}
 
-
-
 			// 設定ＩＤを取得
 			confId = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_ID];
-
-
 
 			// 表示名の欄を生成
 			objTd = document.createElement("td");
@@ -295,16 +238,12 @@ function CConfBase(confArray) {
 				objA.appendChild(objText);
 			}
 
-
-
 			// 設定値の欄を生成
 			objTd = document.createElement("td");
 			objTr.appendChild(objTd);
 
 			controlId = this.GetControlIdString(instanceNo, confId);
 			controlType = this.confDataObj[idx][CConfBase.CONF_DATA_INDEX_CONTROL_TYPE];
-
-
 
 			switch (controlType) {
 
@@ -324,8 +263,6 @@ function CConfBase(confArray) {
 			// 固定テキストの場合
 			case CONTROL_TYPE_TEXT_NODE:
 				break;
-
-
 
 			// 設定方法が数値選択方式の場合
 			case CONTROL_TYPE_SELECTBOX_NUMBER:
@@ -356,8 +293,6 @@ function CConfBase(confArray) {
 
 				break;
 
-
-
 			// 設定方法がチェック方式の場合
 			case CONTROL_TYPE_CHECKBOX:
 
@@ -375,8 +310,6 @@ function CConfBase(confArray) {
 
 				break;
 
-
-
 			// 設定方法が数値入力方式の場合
 			case CONTROL_TYPE_TEXTBOX_NUMBER:
 
@@ -393,8 +326,6 @@ function CConfBase(confArray) {
 
 				break;
 
-
-
 			// 設定方法が特殊方式の場合
 			case CONTROL_TYPE_SELECTBOX_SPECIAL:
 			case CONTROL_TYPE_CHECKBOX_SPECIAL:
@@ -406,8 +337,6 @@ function CConfBase(confArray) {
 			}
 
 		}
-
-
 
 		// 変数の値をもとに、設定欄の各コントロールを同期
 		this.SyncronizeSettingsVarToCtrl();
@@ -431,10 +360,6 @@ function CConfBase(confArray) {
 
 		}
 	};
-
-
-
-
 
 	/**
 	 * 設定欄の状態を同期させる（変数の値をコントロール部品へ反映）.
@@ -513,10 +438,6 @@ function CConfBase(confArray) {
 			}
 		}
 	}
-
-
-
-
 
 	/**
 	 * 設定欄の状態を同期させる（コントロール部品の状態を変数へ反映）.
@@ -599,10 +520,6 @@ function CConfBase(confArray) {
 		}
 	}
 
-
-
-
-
 	/**
 	 * 設定欄の展開スイッチクリックイベントハンドラ.
 	 */
@@ -678,10 +595,6 @@ function CConfBase(confArray) {
 		}
 	}
 
-
-
-
-
 	/**
 	 * 設定欄テーブルのヘッダをリフレッシュする.
 	 */
@@ -720,10 +633,6 @@ function CConfBase(confArray) {
 			objTd.setAttribute("bgcolor", COLOR_CODE_TABLE_HEADER_IS_NOT_SET);
 		}
 	}
-
-
-
-
 
 	/**
 	 * 設定欄の選択状態により、コントロールのCSSを変更する.
@@ -828,8 +737,6 @@ function CConfBase(confArray) {
 			}
 		}
 	}
-
-
 
 	// TODO: 処理構造変えたい
 	/**

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30492,7 +30492,12 @@ function Init(){
 	g_objCharaConfYozi = new CCharaConfYozi(g_confDataYozi);
 	g_objCharaConfYozi.BuildUpSelectArea(document.getElementById("OBJID_TD_CHARA_CONF_YOZI"), false);
 
-
+	//--------------------------------
+	// デバフ設定欄の初期化
+	//--------------------------------
+	g_confDataDebuff = new Array();
+	g_objCharaConfDebuff = new CCharaConfDebuff(g_confDataDebuff);
+	g_objCharaConfDebuff.BuildUpSelectArea(document.getElementById("OBJID_TD_CHARA_CONF_DEBUFF"), false);
 
 	document.calcForm.A3_SKILLSW.checked = 0;
 	document.calcForm.A4_SKILLSW.checked = 0;

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30495,9 +30495,9 @@ function Init(){
 	//--------------------------------
 	// デバフ設定欄の初期化
 	//--------------------------------
-	g_confDataDebuff = new Array();
-	g_objCharaConfDebuff = new CCharaConfDebuff(g_confDataDebuff);
-	g_objCharaConfDebuff.BuildUpSelectArea(document.getElementById("OBJID_TD_CHARA_CONF_DEBUFF"), false);
+//	g_confDataDebuff = new Array();
+//	g_objCharaConfDebuff = new CCharaConfDebuff(g_confDataDebuff);
+//	g_objCharaConfDebuff.BuildUpSelectArea(document.getElementById("OBJID_TD_CHARA_CONF_DEBUFF"), false);
 
 	document.calcForm.A3_SKILLSW.checked = 0;
 	document.calcForm.A4_SKILLSW.checked = 0;

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -5020,13 +5020,6 @@ if (_APPLY_UPDATE_LV200) {
 		if(EquipNumSearch(1042)) w += n_A_Weapon_ATKplus;
 		if(EquipNumSearch(1029) && n_A_HEAD_DEF_PLUS >= 6) w += n_A_HEAD_DEF_PLUS - 5;
 
-		//----------------------------------------------------------------
-		// 「一次職支援　マーダラーボーナス」の、効果
-		//----------------------------------------------------------------
-		if(g_confDataIchizi[CCharaConfIchizi.CONF_ID_MARDERER_BONUS]) {
-			w += 10;
-		}
-
 		if(EquipNumSearch(1083)){
 			w += n_A_Weapon_ATKplus;
 		}
@@ -28159,28 +28152,6 @@ function StPlusCalc() {
 		wSPC_INT += 20;
 		wSPC_LUK += 20;
 	}
-
-	//----------------------------------------------------------------
-	// 「一次職支援　マーダラーボーナス」の効果
-	//----------------------------------------------------------------
-	var vartmp = 0;
-	switch (g_confDataIchizi[CCharaConfIchizi.CONF_ID_MARDERER_BONUS]) {
-	case 1:
-		vartmp = 3;
-		break;
-	case 2:
-		vartmp = 5;
-		break;
-	}
-
-	wSPC_STR += vartmp;
-	wSPC_AGI += vartmp;
-	wSPC_VIT += vartmp;
-	wSPC_DEX += vartmp;
-	wSPC_INT += vartmp;
-	wSPC_LUK += vartmp;
-
-
 
 	if(n_A_PassSkill8[4]){
 		wSPC_STR += 1;

--- a/roro/m/js/mob.js
+++ b/roro/m/js/mob.js
@@ -1515,19 +1515,9 @@ function GetMobDataParameters(monsterId, mobData){
 	}
 
 	//----------------------------------------------------------------
-	// 「一次職支援　マーダラーボーナス」の効果
-	//----------------------------------------------------------------
-	if (g_confDataIchizi[CCharaConfIchizi.CONF_ID_MARDERER_BONUS]) {
-		wAllExp += 100;
-	}
-
-
-	//----------------------------------------------------------------
 	// 「対プレイヤー設定　戦闘エリア」の「Urdr」における効果
-	// 「一次職支援　マーダラーボーナス」の効果
 	//----------------------------------------------------------------
-	if(n_B_TAISEI[MOB_CONF_PLAYER_ID_SENTO_AREA] == MOB_CONF_PLAYER_ID_SENTO_AREA_URDR
-		|| g_confDataIchizi[CCharaConfIchizi.CONF_ID_MARDERER_BONUS]){
+	if(n_B_TAISEI[MOB_CONF_PLAYER_ID_SENTO_AREA] == MOB_CONF_PLAYER_ID_SENTO_AREA_URDR){
 		wAllExp = wAllExp * 2;
 		wJobExp = wJobExp * 2;
 	}


### PR DESCRIPTION
セーブデータには支援設定の順序とLvしか保存されていないので
支援設定の削除や並び替えが困難だと思い込んでいました

しかし支援設定が定義されている順番を支援設定IDと見なすことで
セーブデータのバージョニング無しで
支援設定を削除したり並び替えたりできることが確認出来ました

#909 で歌・踊り設定を追加することを躊躇させていた問題を解消するPOCとして本PRをPushします
