### PR TITLE
Visual Studio Codeのプロジェクト設定ファイル追加要望

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "editor.formatOnSave": true, // 全体のフォーマットを有効化
+    "[javascript]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": false,
+        "editor.formatOnSave": false, // 保存時のフォーマットを無効化
+        "files.insertFinalNewline": false, // ファイル末尾に改行を保持
+        "files.trimTrailingWhitespace": false // 行末の空白を削除しない
+    },
+    "[typescript]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true
+    },
+    "[json]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true
+    },
+    "[jsonc]": {
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true
+    }
+}


### PR DESCRIPTION
VScodeで編集するときに既存のJavaScriptのフォーマットを大幅にリファクタリングしてしまい
差分が大量に出るので一旦無効化した設定をPRします

- JavaScript: タブインデント、フォーマット修正無効化
- TypeScript: スペース4文字インデント固定
- JSON: スペース4文字インデント固定
- JSON with Comments: スペース4文字インデント固定