### PR TITLE
属性付与が効かない問題の修正：振動残響

### DIFF
--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -36698,16 +36698,6 @@ function CSkillManager() {
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_MAGICAL;
 			this.range = CSkillData.RANGE_MAGIC;
 			this.element = CSkillData.ELEMENT_VOID;
-			this.Power = function(skillLv, charaData, option) {
-				// 基本倍率
-				let ratio = 2000 + 500 * skillLv;
-				// ステージマナー習得Lv
-				const stage_manner_lv = Math.max(LearnedSkillSearch(SKILL_ID_STAGE_MANNER), UsedSkillSearch(SKILL_ID_STAGE_MANNER));
-				// SPL補正
-				ratio += 3 * GetTotalSpecStatus(MIG_PARAM_ID_SPL) * stage_manner_lv;
-				// ベースレベル補正
-				ratio = Math.floor(ratio * n_A_BaseLV / 100);
-			}
 			this.CostFixed = function(skillLv, charaDataManger) {       // 消費SP
 				return 55;
 			}


### PR DESCRIPTION
- #1035

属性自動矢が考慮されていないのでこれは暫定処置
矢の属性はコードが分散していてわかりにくいので
将来本格的に触るときに備えて覚書として先に実装しておきます