### PR TITLE
jquery-cookieを使った処理を廃止

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -187,10 +187,12 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.2/jquery.modal.min.css" />
 	<script type="text/javascript" src="../../ro4/m/js/calchistory.js"></script>
 	<!-- 汎用Cookie操作機能 -->
+	<!-- deprecated
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"
 		integrity="sha512-3j3VU6WC5rPQB4Ld1jnLV7Kd5xr+cq9avvhwqzbH/taCRNURoeEpoPBK9pDyeukwSxwRPJ8fDgvYXd6SkaZ2TA=="
 		crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script type="text/javascript" src="../../ro4/m/js/cookiemanager.js"></script>
+	-->
 	<!-- 更新履歴通知トースト -->
 	<script src="https://cdn.jsdelivr.net/npm/jquery-toast-plugin@1.3.2/dist/jquery.toast.min.js"></script>
 	<link href="https://cdn.jsdelivr.net/npm/jquery-toast-plugin@1.3.2/dist/jquery.toast.min.css" rel="stylesheet">

--- a/ro4/m/js/cookiemanager.js
+++ b/ro4/m/js/cookiemanager.js
@@ -1,4 +1,5 @@
 /**
+ * deprecated
  * 計算機の状態をCookieにセーブ、あるいはロードする
  */
 $(function () {

--- a/ro4/m/js/savedata/CSaveDataConst.js
+++ b/ro4/m/js/savedata/CSaveDataConst.js
@@ -1945,7 +1945,85 @@ class CSaveDataConst {
 	 */
 	static propNameCastSimInterval = "castSimInterval";
 
+	/**
+	 * プロパティ名：カスタム表示スイッチ
+	 */
+	static propNameFloatingInfoAreaSwitch = "floatingInfoAreaSwitch";
 
+	/**
+	 * プロパティ名：カスタム表示生成数
+	 */
+	static propNameFloatingInfoAreaCount = "floatingInfoAreaCount";
+
+	/**
+	 * プロパティ名：カスタム表示文字サイズ
+	 */
+	static propNameFloatingInfoAreaFontSize = "floatingInfoAreaFontSize";
+
+	/**
+	 * プロパティ名：カスタム表示１カテゴリ名
+	 */
+	static propNameFloatingInfo1CategoryName = "floatingInfo1CategoryName";
+
+	/**
+	 * プロパティ名：カスタム表示１情報名
+	 */
+	static propNameFloatingInfo1InfoName = "floatingInfo1InfoName";
+
+	/**
+	 * プロパティ名：カスタム表示２カテゴリ名
+	 */
+	static propNameFloatingInfo2CategoryName = "floatingInfo2CategoryName";
+
+	/**
+	 * プロパティ名：カスタム表示２情報名
+	 */
+	static propNameFloatingInfo2InfoName = "floatingInfo2InfoName";
+
+	/**
+	 * プロパティ名：カスタム表示３カテゴリ名
+	 */
+	static propNameFloatingInfo3CategoryName = "floatingInfo3CategoryName";
+
+	/**
+	 * プロパティ名：カスタム表示３情報名
+	 */
+	static propNameFloatingInfo3InfoName = "floatingInfo3InfoName";
+
+	/**
+	 * プロパティ名：カスタム表示４カテゴリ名
+	 */
+	static propNameFloatingInfo4CategoryName = "floatingInfo4CategoryName";
+
+	/**
+	 * プロパティ名：カスタム表示４情報名
+	 */
+	static propNameFloatingInfo4InfoName = "floatingInfo4InfoName";
+
+	/**
+	 * プロパティ名：カスタム表示５カテゴリ名
+	 */
+	static propNameFloatingInfo5CategoryName = "floatingInfo5CategoryName";
+
+	/**
+	 * プロパティ名：カスタム表示５情報名
+	 */
+	static propNameFloatingInfo5InfoName = "floatingInfo5InfoName";
+
+	/**
+	 * プロパティ名：アイテム情報スイッチ
+	 */
+	static propNameItemInfoSwitch = "itemInfoSwitch";
+
+	/**
+	 * プロパティ名：アイテム情報自動表示スイッチ
+	 */
+	static propNameItemInfoAutoSwitch = "itemInfoAutoSwitch";
+
+	/**
+	 * プロパティ名：アイテム情報時限効果スイッチ
+	 */
+	static propNameItemInfoTimeEffectSwitch = "itemInfoTimeEffectSwitch";
 
 	/**
 	 * プロパティ値：装備位置種別（アイテム）.

--- a/roro/m/js/CExtraInfoAreaComponentManager.js
+++ b/roro/m/js/CExtraInfoAreaComponentManager.js
@@ -345,6 +345,9 @@ function CExtraInfoAreaComponentManager () {
 		// 選択中のＩＤを更新
 		this.selectedInfoId = infoId;
 
+		// セーブデータ更新
+		CSaveController.setSettingProp(`floatingInfo${this.managerInstanceId}InfoName`, infoId);
+		
 		// 再構築処理呼び出し
 		this.RebuildDispArea();
 	};

--- a/roro/m/js/CFloatingInfoAreaComponentManager.js
+++ b/roro/m/js/CFloatingInfoAreaComponentManager.js
@@ -372,8 +372,12 @@ CFloatingInfoAreaComponentManager.RebuildControls = function () {
  * 展開チェックボックス切り替えイベントハンドラ.
  */
 CFloatingInfoAreaComponentManager.OnClickExtractSwitch = function () {
+	// セーブデータ更新
+	const status = document.getElementById("OBJID_FLOATING_INFO_AREA_EXTRACT_CHECKBOX").checked ? 1 : 0;
+	CSaveController.setSettingProp(CSaveDataConst.propNameFloatingInfoAreaSwitch, status);
 	// 再構築する
 	CFloatingInfoAreaComponentManager.RebuildControls();
+	CFloatingInfoAreaComponentManager.LoadFromLocalStorage();
 };
 
 
@@ -382,10 +386,11 @@ CFloatingInfoAreaComponentManager.OnClickExtractSwitch = function () {
  * フローティング情報欄の数変更イベントハンドラ.
  */
 CFloatingInfoAreaComponentManager.OnChangeAreaCount = function () {
-
+	// セーブデータ更新
+	const count = document.getElementById("OBJID_SELECT_FLOATING_INFO_AREA_COUNT").value
+	CSaveController.setSettingProp(CSaveDataConst.propNameFloatingInfoAreaCount, count);
 	// 情報欄の数を更新
 	CFloatingInfoAreaComponentManager.areaCount = HtmlGetObjectValueByIdAsInteger("OBJID_SELECT_FLOATING_INFO_AREA_COUNT", 1);
-
 	// 全部品再構築処理呼び出し
 	CFloatingInfoAreaComponentManager.RebuildControls();
 };
@@ -396,15 +401,13 @@ CFloatingInfoAreaComponentManager.OnChangeAreaCount = function () {
  * フローティング情報ＩＤ変更イベントハンドラ.
  */
 CFloatingInfoAreaComponentManager.OnChangeInfo = function (idxArea) {
-
 	var infoId = 0;
-
 	// フローティング情報ＩＤを取得
 	infoId = HtmlGetObjectValueByIdAsInteger("OBJID_SELECT_FLOATING_INFO_" + idxArea, 0);
-
 	// 選択中のＩＤを更新
 	CFloatingInfoAreaComponentManager.infoUnitArray[idxArea].selectedInfoId = infoId;
-
+	// セーブデータ更新
+	CSaveController.setSettingProp(`floatingInfo${idxArea + 1}CategoryName`, infoId);
 	// 再構築処理呼び出し
 	CFloatingInfoAreaComponentManager.RebuildDispArea(idxArea);
 };
@@ -1158,12 +1161,30 @@ CFloatingInfoAreaComponentManager.RefreshDispAreaNotice = function (idxArea) {
 
 };
 
-
-
-
-
-
-
+/**
+ * ローカルストレージに保存された状態を復元する
+ */
+CFloatingInfoAreaComponentManager.LoadFromLocalStorage = function () {
+	const event = new Event('change', { bubbles: true });
+	// 表示欄の数を設定する
+	const floating_info_area_count = Number(CSaveController.getSettingProp(CSaveDataConst.propNameFloatingInfoAreaCount));
+	const selectElement = document.getElementById("OBJID_SELECT_FLOATING_INFO_AREA_COUNT");
+	selectElement.value = floating_info_area_count;
+	selectElement.dispatchEvent(event);
+	// 文字サイズを設定する
+	//      TODO: 文字サイズを相対指定出来るようになってから実装する
+	for (let i=0; floating_info_area_count > i; i++) {
+		// カスタム表示本体を設定する
+		const category_id = Number(CSaveController.getSettingProp(`floatingInfo${i + 1}CategoryName`));
+		const info_id = Number(CSaveController.getSettingProp(`floatingInfo${i + 1}InfoName`));
+		const categoryElement = document.getElementById(`OBJID_SELECT_FLOATING_INFO_${i}`);
+		categoryElement.value = category_id;
+		categoryElement.dispatchEvent(event);
+		const infoElement = document.getElementById(`OBJID_SELECT_EXTRA_INFO_${i + 1}`);
+		infoElement.value = info_id;
+		infoElement.dispatchEvent(event);
+	}	
+}
 
 //--------------------------------------------------------------------------------
 // 各フローティング情報ごとの表示欄構築関数ここまで

--- a/roro/m/js/CItemInfoManager.js
+++ b/roro/m/js/CItemInfoManager.js
@@ -276,8 +276,12 @@ CItemInfoManager.RebuildControls = function () {
  * 展開チェックボックス切り替えイベントハンドラ.
  */
 CItemInfoManager.OnClickExtractSwitch = function () {
+	// セーブデータ更新
+	const status = document.getElementById("OBJID_ITEM_INFO_EXTRACT_CHECKBOX").checked ? 1 : 0;
+	CSaveController.setSettingProp(CSaveDataConst.propNameItemInfoSwitch, status);
 	// 再構築する
 	CItemInfoManager.RebuildControls();
+	CItemInfoManager.LoadFromLocalStorage();
 };
 
 
@@ -286,17 +290,12 @@ CItemInfoManager.OnClickExtractSwitch = function () {
  * 自動表示チェックボックス変更イベントハンドラ.
  */
 CItemInfoManager.OnChangeCheckAutoFlag = function () {
-
 	var objInput = null;
-
 	objInput = document.getElementById("OBJID_CHECK_ITEM_INFO_AUTO_FLAG");
-
-	if (objInput.checked) {
-		CItemInfoManager.AutoFlag = true;
-	}
-	else {
-		CItemInfoManager.AutoFlag = false;
-	}
+	CItemInfoManager.AutoFlag = objInput.checked;
+	// セーブデータ更新
+	const status = objInput.checked?1:0;
+	CSaveController.setSettingProp(CSaveDataConst.propNameItemInfoAutoSwitch, status);
 };
 
 
@@ -305,17 +304,12 @@ CItemInfoManager.OnChangeCheckAutoFlag = function () {
  * 時限効果設定時画面フォーカスチェックボックス変更イベントハンドラ.
  */
 CItemInfoManager.OnChangeCheckApplyAutoFocusFlag = function () {
-
 	var objInput = null;
-
 	objInput = document.getElementById("OBJID_CHECK_ITEM_INFO_APPLY_AUTO_FOCUS_FLAG");
-
-	if (objInput.checked) {
-		CItemInfoManager.ApplyAutoFocusFlag = true;
-	}
-	else {
-		CItemInfoManager.ApplyAutoFocusFlag = false;
-	}
+	CItemInfoManager.ApplyAutoFocusFlag = objInput.checked;
+	// セーブデータ更新
+	const status = objInput.checked?1:0;
+	CSaveController.setSettingProp(CSaveDataConst.propNameItemInfoTimeEffectSwitch, status);
 };
 
 
@@ -1322,7 +1316,17 @@ CItemInfoManager.ApplyTimeItem = function (timeItemId) {
 	}
 };
 
-
+/**
+ * ローカルストレージに保存された状態を復元する
+ */
+CItemInfoManager.LoadFromLocalStorage = function () {
+	// 自動表示の状態を設定する
+	let status = Number(CSaveController.getSettingProp(CSaveDataConst.propNameItemInfoAutoSwitch)) == 1n;
+	document.getElementById("OBJID_CHECK_ITEM_INFO_AUTO_FLAG").checked = status;
+	// 時限効果フォーカスの状態を設定する
+	status = Number(CSaveController.getSettingProp(CSaveDataConst.propNameItemInfoTimeEffectSwitch)) == 1n;
+	document.getElementById("OBJID_CHECK_ITEM_INFO_APPLY_AUTO_FOCUS_FLAG").checked = status;
+}
 
 /**
  * セット情報を追記する.

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30104,111 +30104,106 @@ const EnName =["なし","水","地","火","風","毒","聖","闇","念","死"];
 // 他の関数実行に先駆けて初期化される必要があるので load だとタイミングが遅い. DOMContentLoaded を指定する必要がある.
 document.addEventListener('DOMContentLoaded', () => {
 	console.log("DOM Content is loaded.");
-	// 計算機設定の読み込み
-	if (document.getElementById("OBJID_SAVE_BLOCK_MIG")) {
-		CSaveController.LoadSettingFromLocalStorageMIG();
-	}
-
-	// 職業選択セレクトボックスの構築
-	var idx = 0;
-	var jobIdArray = null;
-	jobIdArray = g_constDataManager.GetDataManger(CONST_DATA_KIND_JOB).EnumId();
-	for (idx = 0; idx < jobIdArray.length; idx++) {
-		document.calcForm.A_JOB.options[idx] = new Option(GetJobName(jobIdArray[idx]), jobIdArray[idx]);
-	}
-
-	document.calcForm.A_SpeedPOT.options[0] = new Option(SpeedPotName[0],0);
-	document.calcForm.A_SpeedPOT.options[1] = new Option(SpeedPotName[1],1);
-
-	for (i=0;i<=9;i++) {
-		document.calcForm.A_Weapon_zokusei.options[i] = new Option(EnName[i],i);
-	}
-	
-	CMonsterMapAreaComponentManager.RebuildControls();
-
-	//--------------------------------
-	// モンスター手入力設定欄の初期化
-	//--------------------------------
-	g_objMobConfInput = new CMobConfInputAreaComponentManager(g_dataManagerMobConfInput);
-	g_objMobConfInput.BuildUpSelectArea(document.getElementById("OBJID_TD_MOB_CONF_INPUT_NEW"), false);
-
-	n_A_JOB = 0;
-	document.calcForm.A_JOB.value = 0;
-	changeJobSettings(0);
-
-	//--------------------------------
-	// ステートフルデータの初期化
-	//--------------------------------
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ARMS);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ARMS_LEFT);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_TOP);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_MID);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_UNDER);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHIELD);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_BODY);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHOULDER);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHOES);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1);
-	UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2);
-
-	if (document.getElementById("OBJID_SAVE_BLOCK_MIG")) {
-		CSaveController.LoadFromLocalStorageMIG();
-		// 画面上部セーブ選択セレクトボックスの初期化
-		const objSelect = document.getElementById("OBJID_SELECT_SAVE_DATA_MIG");
-		HtmlRemoveAllChild(objSelect)
-		for (let idx = 0; idx < CSaveController.CHARA_DATA_COUNT; idx++) {
-			const optText = CSaveController.getDisplayName(idx);
-			HtmlCreateElementOption(idx, optText, objSelect);
+	// YAMLデータのロードが完了していたら発火
+	waitForDataLoaded().then(() => {
+		// 計算機設定の読み込み
+		if (document.getElementById("OBJID_SAVE_BLOCK_MIG")) {
+			CSaveController.LoadSettingFromLocalStorageMIG();
 		}
-		// 確認ダイアログの有効化スイッチを初期化
-		if (CSaveController.getSettingProp(CSaveDataConst.propNameConfirmDialogSwitch) == 1) {
-			$("#OBJID_SWITCH_CONFIRM_DIALOG").click();
+
+		document.calcForm.A_SpeedPOT.options[0] = new Option(SpeedPotName[0],0);
+		document.calcForm.A_SpeedPOT.options[1] = new Option(SpeedPotName[1],1);
+
+		for (var i=0; i<=9; i++) {
+			document.calcForm.A_Weapon_zokusei.options[i] = new Option(EnName[i],i);
 		}
-	}
-	else {
-		LoadSaveDataToCalculator();
-	}
 
-	// 旧形式のロード処理はコメントアウト
-	//URLIN(location.href);
+		CMonsterMapAreaComponentManager.RebuildControls();
 
-	/**
-	 * 新形式を前提としたロード処理
-	 * 初代の a 形式
-	 * 避難所の b 形式
-	 * Hub の c 形式
-	 * どれも読み込めることを確認
-	 */
-	let splittedArray = location.href.split("?");
-	if (splittedArray.length == 2) {
-		CSaveController.loadFromURL(splittedArray[1]);
-		CItemInfoManager.OnClickExtractSwitch();
-	}
+		//--------------------------------
+		// モンスター手入力設定欄の初期化
+		//--------------------------------
+		g_objMobConfInput = new CMobConfInputAreaComponentManager(g_dataManagerMobConfInput);
+		g_objMobConfInput.BuildUpSelectArea(document.getElementById("OBJID_TD_MOB_CONF_INPUT_NEW"), false);
 
-	// 再計算
-	CalcStatusPoint(true);
-	calc();
+		//--------------------------------
+		// ステートフルデータの初期化
+		//--------------------------------
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ARMS);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ARMS_LEFT);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_TOP);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_MID);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_HEAD_UNDER);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHIELD);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_BODY);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHOULDER);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_SHOES);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ACCESSARY_1);
+		UpdateStatefullDataOnChangeEquip(EQUIP_REGION_ID_ACCESSARY_2);
 
-	/**
-	 * カスタム表示の状態を復元する
-	 * 装備・ステータスに依存するカスタム表示欄があるので再計算後に実施する
-	 */
-	if (CSaveController.getSettingProp(CSaveDataConst.propNameFloatingInfoAreaSwitch) == 1) {
-		// カスタム表示を開く
-		document.getElementById("OBJID_FLOATING_INFO_AREA_EXTRACT_CHECKBOX").click();
-		// 中身を復元する
-		CFloatingInfoAreaComponentManager.LoadFromLocalStorage();
-	}
-	/**
-	 * アイテム情報の状態を復元する
-	 */
-	if (CSaveController.getSettingProp(CSaveDataConst.propNameItemInfoSwitch) == 1) {
-		// カスタム表示を開く
-		document.getElementById("OBJID_ITEM_INFO_EXTRACT_CHECKBOX").click();
-		// 中身を復元する
-		CItemInfoManager.LoadFromLocalStorage();
-	}
+		if (document.getElementById("OBJID_SAVE_BLOCK_MIG")) {
+			CSaveController.LoadFromLocalStorageMIG();
+			// 画面上部セーブ選択セレクトボックスの初期化
+			const objSelect = document.getElementById("OBJID_SELECT_SAVE_DATA_MIG");
+			HtmlRemoveAllChild(objSelect)
+			for (let idx = 0; idx < CSaveController.CHARA_DATA_COUNT; idx++) {
+				const optText = CSaveController.getDisplayName(idx);
+				HtmlCreateElementOption(idx, optText, objSelect);
+			}
+			// 確認ダイアログの有効化スイッチを初期化
+			if (CSaveController.getSettingProp(CSaveDataConst.propNameConfirmDialogSwitch) == 1) {
+				$("#OBJID_SWITCH_CONFIRM_DIALOG").click();
+			}
+		}
+		else {
+			LoadSaveDataToCalculator();
+		}
 
+		/**
+		 * 新形式を前提としたロード処理
+		 * 初代の a 形式
+		 * 避難所の b 形式
+		 * Hub の c 形式
+		 * どれも読み込めることを確認
+		 */
+		// URL引数のチェック
+		const query = window.location.search;
+		const param = query.replace("?", "");
+		const patternRtx = /^rtx[0-9]+:/
+		if (param.length > 0 && !patternRtx.test(param)) {
+			// ラトリオ独自のロード処理
+			CSaveController.loadFromURL(param);
+			CItemInfoManager.OnClickExtractSwitch();
+		} else {
+			// URLロードがない場合は、ノービスを初期ジョブとして設定
+			changeJobSettings("NOVICE");
+		}
+
+		// 再計算
+		CalcStatusPoint(true);
+		calc();
+		
+		/**
+		 * カスタム表示の状態を復元する
+		 * 装備・ステータスに依存するカスタム表示欄があるので再計算後に実施する
+		 */
+		if (CSaveController.getSettingProp(CSaveDataConst.propNameFloatingInfoAreaSwitch) == 1) {
+			// カスタム表示を開く
+			document.getElementById("OBJID_FLOATING_INFO_AREA_EXTRACT_CHECKBOX").click();
+			// 中身を復元する
+			CFloatingInfoAreaComponentManager.LoadFromLocalStorage();
+		}
+		/**
+		 * アイテム情報の状態を復元する
+		 */
+		if (CSaveController.getSettingProp(CSaveDataConst.propNameItemInfoSwitch) == 1) {
+			// カスタム表示を開く
+			document.getElementById("OBJID_ITEM_INFO_EXTRACT_CHECKBOX").click();
+			// 中身を復元する
+			CItemInfoManager.LoadFromLocalStorage();
+		}
+
+	});
 });
 
 function LoadSaveDataToCalculator () {

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -30188,6 +30188,27 @@ document.addEventListener('DOMContentLoaded', () => {
 	// 再計算
 	CalcStatusPoint(true);
 	calc();
+
+	/**
+	 * カスタム表示の状態を復元する
+	 * 装備・ステータスに依存するカスタム表示欄があるので再計算後に実施する
+	 */
+	if (CSaveController.getSettingProp(CSaveDataConst.propNameFloatingInfoAreaSwitch) == 1) {
+		// カスタム表示を開く
+		document.getElementById("OBJID_FLOATING_INFO_AREA_EXTRACT_CHECKBOX").click();
+		// 中身を復元する
+		CFloatingInfoAreaComponentManager.LoadFromLocalStorage();
+	}
+	/**
+	 * アイテム情報の状態を復元する
+	 */
+	if (CSaveController.getSettingProp(CSaveDataConst.propNameItemInfoSwitch) == 1) {
+		// カスタム表示を開く
+		document.getElementById("OBJID_ITEM_INFO_EXTRACT_CHECKBOX").click();
+		// 中身を復元する
+		CItemInfoManager.LoadFromLocalStorage();
+	}
+
 });
 
 function LoadSaveDataToCalculator () {


### PR DESCRIPTION
これは実験的なPRです

いままでは "カスタム表示" の状態を読み込むために jquery-cookie を使用していましたが
#1076 をマージするとjQueryの実行に失敗する**ことがある**事象を確認しています

本PRでは #812 を解決することで jquery-cookie をコードベースから取り除きました
さらに `waitForDataLoaded().then()` の中で "カスタム表示" の状態を読み込むことで
#1076 のメインの処理と実行タイミングが衝突しないようにしています

実際に本 PR を #1076 にマージすることで
error-1
- 「カスタム表示 > ダメージ耐性」を表示している状態がグローバル設定に保存されていて
- セーブデータをURLに貼り付けて読み込んだ時

は発生しなくなったように見えます

**本PRは1076に当てるパッチを意図しており単体ではエラーが発生します.
もし単体で使用する場合は waitForDataLoaded のコメントアウトが必要です.**