### PR TITLE
上限解放 -275- ドラゴニックブレス, ホークブーメラン

### DIFF
--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -40648,7 +40648,7 @@ function CSkillManager() {
 			this.prototype = new CSkillData();
 			CSkillData.call(this);
 			this.id = skillId;
-			this.name = "ドラゴニックブレス";
+			this.name = "(△)ドラゴニックブレス";
 			this.kana = "トラコニツクフレス";
 			this.maxLv = 10;
 			this.type = CSkillData.TYPE_ACTIVE | CSkillData.TYPE_PHYSICAL;
@@ -40670,8 +40670,10 @@ function CSkillManager() {
 					ratio = 2750 + 325 * skillLv;
 					ratio += 20 * GetTotalSpecStatus(MIG_PARAM_ID_POW);
 				}
-				ratio += charaData[CHARA_DATA_INDEX_MAXHP] / 500;
-				ratio += charaData[CHARA_DATA_INDEX_MAXSP] / 20;
+				// 2025-08-26 アップデート後の実測値に対して計算値が僅かにオーバーする
+				// HPSP係数が間違っているか他の計算部分で誤差が生じている
+				ratio += charaData[CHARA_DATA_INDEX_MAXHP] / 320
+				ratio += charaData[CHARA_DATA_INDEX_MAXSP] / 12;
 				ratio = Math.floor(ratio * n_A_BaseLV / 100);
 				return ratio;
 			}

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -32909,7 +32909,7 @@ function CSkillManager() {
 				return this._CriActRate100(skillLv, charaData, specData, mobData);
 			}
 			this.CriDamageRate = (skillLv, charaData, specData, mobData) => {
-				return this._CriDamageRate100(skillLv, charaData, specData, mobData) * 1.25;
+				return this._CriDamageRate100(skillLv, charaData, specData, mobData) * 0.5;
 			}
 		};
 		this.dataArray[skillId] = skillData;


### PR DESCRIPTION
## ドラゴニックブレス
MaxHPとMaxHPに影響を受ける量を増加させました
誤差が残っておりゲーム内の実測値よりも僅かに大きな値が計算されます
- #1048

## ホークブーメラン
アイテムなどの効果「クリティカル攻撃で与えるダメージ＋◯」が適用される際の倍率を修正しました
修正前：1.25 倍
修正後：0.5 倍