### PR TITLE
バグ修正：必中など一部の値がNaNと表示される

### DIFF
--- a/ro4/m/js/BuffJobSpecificSelf.js
+++ b/ro4/m/js/BuffJobSpecificSelf.js
@@ -770,9 +770,9 @@ function UsedSkillSearch(sklId, bOnlyUsed = false) {
 }
 
 /**
- * 有効化されている「職固有自己支援」の設定Lvを取得する
+ * 有効化されている「職固有自己支援」の設定Lvを取得する. 
  * @param {Number} sklId 確認するスキル
- * @returns {Number} 設定されているLv
+ * @returns {Number} 設定されているLv. 異常な値がセットされている場合は何も返さない.
  */
 function UsedSkillSearchSubUsedOnly(sklId) {
 	// 設定可能な全ての職固有自己支援スキルを取得する

--- a/ro4/m/js/hmjob.js
+++ b/ro4/m/js/hmjob.js
@@ -1344,6 +1344,7 @@ function ApplySpecModify(spid, spVal) {
 
 		// 「インクイジター」スキル「忠実な信念」習得による効果
 		if ((sklLv = UsedSkillSearch(SKILL_ID_CHUZITSUNA_SHINNEN)) > 0) {
+			sklLv = ValueRangeModify(sklLv, 0, 5);
 			spVal += [0, 1, 3, 5, 10, 15][sklLv];
 		}
 		break;

--- a/roro/common/js/util.js
+++ b/roro/common/js/util.js
@@ -405,6 +405,50 @@ function HtmlSetObjectValueById(objID, valutToSet) {
 	objTarget.value = valutToSet;
 }
 
+/**
+ * 指定されたselect要素の取りうる値の最小値と最大値を取得する
+ * @param {string} selectId - select要素のID
+ * @returns {{min: number, max: number} | null} 値の範囲、または要素が見つからない場合はnull
+ */
+function getSelectValueRange(selectId) {
+  const selectElement = document.getElementById(selectId);
+  
+  // 指定されたIDの要素が見つからない場合はnullを返す
+  if (!selectElement) {
+    return null;
+  }
+  if (selectId === "A_skill15") {
+	console.log(selectId)
+  }
+
+  // <option>要素のリストを取得
+  const options = selectElement.options;
+  
+  // 値を格納する配列を初期化
+  const values = [];
+
+  // 各optionのvalueを配列に追加
+  for (let i = 0; i < options.length; i++) {
+    // 数値としてパースして格納する
+    const value = parseFloat(options[i].value);
+    // 有効な数値であることを確認
+    if (!isNaN(value)) {
+      values.push(value);
+    }
+  }
+
+  // 値がない場合はnullを返す
+  if (values.length === 0) {
+    return null;
+  }
+
+  // 最小値と最大値を取得して返す
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values)
+  };
+}
+
 /************************************************************************************************
  *
  * ＨＴＭＬオブジェクトの value 値を範囲内に補正する.
@@ -571,6 +615,13 @@ function WriteConsoleLog(msg) {
 	console.log(GetLogText(msg));
 }
 
+/**
+ * 数値を指定された最小値と最大値の間にクランプする
+ * @param {number} value 
+ * @param {number} min 
+ * @param {number} max 
+ * @returns {number} クランプされた値
+ */
 function ValueRangeModify(value, min, max) {
 
 	if (isNaN(parseInt(value))) {


### PR DESCRIPTION
一部のセーブデータで職固有自己支援が正常に読み込まれず
必中などのパラメータが NaN と表示される不具合が報告されています

根本的な対応方法を検討していますが少し時間がかかりそうなので
まずは報告されたセーブデータで必中が正常に計算されるよう修正しました

この問題は #1113 として引き続き対応していきます