### PR TITLE
モンスターデータ一覧の検索機能拡張

### DIFF
--- a/roro/other/js/hmmonsterlist.js
+++ b/roro/other/js/hmmonsterlist.js
@@ -333,6 +333,29 @@ function RefreshMonsterList() {
 		);
 	}
 
+	// ソートの 範囲 を特定する
+	var objLow = document.getElementById("OBJID_INPUT_LOW");
+	var LowNum = parseInt(objLow.value, 10);
+	var objHigh = document.getElementById("OBJID_INPUT_HIGH");
+	var HighNum = parseInt(objHigh.value, 10);
+
+	// 下限値でフィルタリング
+	if (!isNaN(LowNum)) {
+		dataArraySorted = dataArraySorted.filter(
+			function (i) {
+				return i[sortKeyIndex] >= LowNum;
+			}
+		);
+	}
+
+	// 上限値でフィルタリング
+	if (!isNaN(HighNum)) {
+		dataArraySorted = dataArraySorted.filter(
+			function (i) {
+				return i[sortKeyIndex] <= HighNum;
+			}
+		);
+	}
 
 
 

--- a/roro/other/monsterlist.html
+++ b/roro/other/monsterlist.html
@@ -178,6 +178,15 @@
 								<select id="OBJID_SELECT_SIZE" onChange="RefreshMonsterList()">
 								</select>
 							</td>
+							<td class="CSSCLS_OPTION_AREA_COND">
+								抽出範囲
+							</td>
+							<td class="CSSCLS_OPTION_AREA_COND" colspan="5">
+								<input id="OBJID_INPUT_LOW" onChange="RefreshMonsterList()">
+								～
+								<input id="OBJID_INPUT_HIGH" onChange="RefreshMonsterList()">
+								
+							</td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
任意のパラメータが一定の範囲にあるモンスターだけを
フィルタリングして表示する機能を追加しました

例：95%FLEEが500から600の間にあるモンスターを表示した様子
<img width="80%" alt="{FB07EC3B-FE2F-40FC-98BA-55186F6A2390}" src="https://github.com/user-attachments/assets/bdfd6e66-4a54-45e4-bcce-5e70ca69bca1" />
