### PR TITLE
バグ修正：スーパーノービスのJobLv最大値

### DIFF
--- a/workspace/data/job.yaml
+++ b/workspace/data/job.yaml
@@ -8115,7 +8115,7 @@ SUPERNOVICE:
   id_num: 23
   is_doram: false
   is_rebirthed: false
-  job_lv_max: 50
+  job_lv_max: 99
   job_type_name: super_novice
   job_type_num: 9
   learned_skills:


### PR DESCRIPTION
2025-08-26 の内部処理変更時から
スーパーノービスのJobLv最大値が誤って50に設定されていました
不具合報告ありがとうございました