### PR TITLE
エンチャント検索へのショートカット

### DIFF
--- a/ro4/m/calcx.css
+++ b/ro4/m/calcx.css
@@ -462,3 +462,22 @@ input[type="number"]:invalid::after {
     align-items: center;
     justify-content: center;
 }
+
+/* エンチャント検索ショートカットボタン */
+.ench-search-shortcut-btn {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    padding: 5px 2px;
+    opacity: 0.2;
+}
+.ench-search-shortcut-btn::before {
+    content: '🔍';
+}
+.ench-search-shortcut-parent:hover .ench-search-shortcut-btn {
+    opacity: 1;
+}

--- a/roro/m/js/hmcard.js
+++ b/roro/m/js/hmcard.js
@@ -564,6 +564,10 @@ if (!_ENCH_LIST_MIG) {
 		}
 
 		HtmlRemoveAllChild(objArySlots[idx]);
+
+		// エンチャント検索ショートカットボタンの削除
+		var enchSearchBtn = objArySlots[idx].parentNode.querySelector('.ench-search-shortcut-btn');
+		if (enchSearchBtn) enchSearchBtn.remove();
 	}
 
 
@@ -1227,6 +1231,31 @@ function BuildUpCardSlotsMIG(eqpRgnId, itemId, enchInfoArray, objArySlots) {
 				// 選択肢を追加
 				HtmlCreateElementOption(cardId, cardName, objSelectGroup);
 			}
+
+			// エンチャント検索ショートカットボタン
+			(function(selectEl) {
+				var parent = selectEl.parentNode;
+				parent.style.position = 'relative';
+				parent.classList.add('ench-search-shortcut-parent');
+
+				var searchBtn = document.createElement('button');
+				searchBtn.type = 'button';
+				searchBtn.className = 'ench-search-shortcut-btn';
+				searchBtn.title = 'エンチャント検索';
+				searchBtn.addEventListener('click', function() {
+					var enchId = selectEl.value;
+					if (!enchId || enchId == '0') return;
+					var $enchSearch = $('#ench_search');
+					if ($enchSearch.length === 0) return;
+					// 同じエンチャントで検索中なら解除、そうでなければ検索
+					if ($enchSearch.val() === enchId) {
+						$enchSearch.val('').trigger('change').trigger('select2:select');
+					} else {
+						$enchSearch.val(enchId).trigger('change').trigger('select2:select');
+					}
+				});
+				parent.appendChild(searchBtn);
+			})(objSelect);
 
 			// カード用の処理はしない
 			continue;


### PR DESCRIPTION
## 解決したいこと
* エンチャントを別装備で探すユースケースを快適にする

## このPRで変わること
* 各スロットの「エンチャント情報」の右端に「虫眼鏡」ボタンを追加
* 「エンチャント検索」へのショートカットとして機能する

![ench_shortcut](https://github.com/user-attachments/assets/221808e7-ab3c-40d8-8218-1fd3bfde3f19)

## 良い点
* `BuildUpCardSlotsMIG` 内の「エンチャント」を対象（カードはうまく除外）
* 変更は局所的、かつIIFEラップのため、グローバル汚染なし＆デグレもない（はず）
* 文字でなく虫眼鏡にし、表示も重ねているので横幅にも優しい

## 迷った点
* CSSを追い出すかどうか (1行だし、変更が1箇所で閉じてる事を優先)
* ゴチャゴチャ感が多少あるかも（通常は一応opacity入れてる）

