### PR TITLE
バグ修正：アイテム情報欄の表示がおかしくなる問題

### DIFF
--- a/ro4/m/js/CSaveDataManager.js
+++ b/ro4/m/js/CSaveDataManager.js
@@ -338,6 +338,7 @@ class CSaveDataManager {
 		this.#collectDataShadowEquips();
 		this.doCompaction();
 		this.applyDataToControls();
+		CItemInfoManager.RebuildControls();
 	}
 
 


### PR DESCRIPTION
アイテム情報欄を開いた状態で「Clip」をクリックすると表示がおかしくなる問題を修正しました。