### PR TITLE
特性ステータス入力欄にキャップ機能を適用

### DIFF
--- a/ro4/m/js/hmjob.js
+++ b/ro4/m/js/hmjob.js
@@ -157,6 +157,11 @@ function CalcStatusPoint(bIgnoreAutoCalc) {
 		for (var blv = 1; blv <= blvSelected; blv++) {
 			stPointEarned += GetEarningStatusPoint(blv);
 		}
+		if (IsYojiJob(migJobIdNum)) {
+			for (blv = blvSelected; (stTSPointEarned < stTSPointUsed) && (blv <= blvSelected); blv++) {
+				stTSPointEarned = GetEarningTSStatusPoint(blv);
+			}
+		}
 	}
 	// レベルの自動計算をする場合
 	else {
@@ -188,7 +193,7 @@ function CalcStatusPoint(bIgnoreAutoCalc) {
 	let bPointCap = CSaveController.getSettingProp(CSaveDataConst.propNamePointCap);
 	if (bPointCap) {
 		// ステータスポイントを超えていたら値を戻す
-		if ((stPointEarned - stPointUsed) < 0) {
+		if (((stPointEarned - stPointUsed) < 0) || ((stTSPointEarned - stTSPointUsed) < 0)) {
 			with(document.calcForm) {
 				A_STR.value = g_STR;
 				A_AGI.value = g_AGI;


### PR DESCRIPTION
ポイントの上限を超えてステータスを割り振れないようにする機能を
特性ステータス入力欄にも適用しました

[![](https://i.gyazo.com/3d8f4778dd266173e53af4f73b3856a9.gif)](https://gyazo.com/3d8f4778dd266173e53af4f73b3856a9)

この機能を有効化するには動作設定メニューを確認してください

<img src="https://github.com/user-attachments/assets/1a598ed4-dc81-499f-b34c-c8b0cf898afe">