### PR TITLE
fix: history_list の ReferenceError / TypeError を修正

### DIFF
--- a/ro4/m/js/CSaveController.js
+++ b/ro4/m/js/CSaveController.js
@@ -758,6 +758,7 @@ export class CSaveController {
 			  datasets: [{
 			    label: "DPS",
 			    data: [],
+			    metadata: [],
 			    borderColor: "#005AFF",
 			    yAxisID: "y",
 			  }, {
@@ -906,7 +907,7 @@ export class CSaveController {
 		    const reload_history_table = () => {
 		      $("#clip_modal_table tbody *").remove();
 		      let body = ""
-		      for (i = 0; i < data.labels.length; i++) {
+		      for (let i = 0; i < data.labels.length; i++) {
 		        body += `<tr>
 		                  <td class="col no">${data.labels[i].toLocaleString()}</td>
 		                  <td class="col">${data.datasets[0].data[i].toLocaleString()}</td>
@@ -922,6 +923,7 @@ export class CSaveController {
 		      $(e.target).next("input").toggle().focus();
 		    });
 		    $(document).on("change", "input.clip_memo", (e) => {
+		      if (window.g_Chart !== chart) return;
 		      const index = e.target.closest("tr").rowIndex - 1;
 		      data.datasets[0].metadata[index]["memo"] = e.target.value;
 		      chart.update();
@@ -933,8 +935,9 @@ export class CSaveController {
 		      $(e.target).prev("div").toggle();
 		    });
 		    $(document).on("click", ".up_clip", (e) => {
+		      if (window.g_Chart !== chart) return;
 		      const row = e.target.closest("tr");
-		      if (row.previousElementSibling) {
+		      if (row && row.previousElementSibling) {
 		        const index = row.rowIndex - 1;
 		        flip_clip(index, index - 1);
 		        chart.update();
@@ -943,8 +946,9 @@ export class CSaveController {
 		      }
 		    });
 		    $(document).on("click", ".down_clip", (e) => {
+		      if (window.g_Chart !== chart) return;
 		      const row = e.target.closest("tr");
-		      if (row.nextElementSibling) {
+		      if (row && row.nextElementSibling) {
 		        const index = row.rowIndex - 1;
 		        flip_clip(index, index + 1);
 		        chart.update();
@@ -953,6 +957,7 @@ export class CSaveController {
 		      }
 		    });
 		    $(document).on("click", ".remove_clip", (e) => {
+		      if (window.g_Chart !== chart) return;
 		      const row = e.target.closest("tr");
 		      const index = row.rowIndex - 1;
 		      data.labels.pop();

--- a/ro4/m/js/calchistory.js
+++ b/ro4/m/js/calchistory.js
@@ -72,6 +72,7 @@ div.clip_memo {
       datasets: [{
         label: "DPS",
         data: [],
+        metadata: [],
         borderColor: "#005AFF",
         yAxisID: "y",
       }, {
@@ -146,6 +147,8 @@ div.clip_memo {
         }
       }
     });
+    g_Chart = chart;
+    if (typeof window !== 'undefined') window.g_Chart = g_Chart;
     $("#history_clip").click(e => {
       // 直前の敵と同じか？
       if (target != $(".OBJID_MONSTER_MAP_MONSTER").val()) {
@@ -232,6 +235,7 @@ div.clip_memo {
       $(e.target).next("input").toggle().focus();
     });
     $(document).on("change", "input.clip_memo", (e) => {
+      if (typeof window !== 'undefined' && window.g_Chart !== chart) return;
       const index = e.target.closest("tr").rowIndex - 1;
       data.datasets[0].metadata[index]["memo"] = e.target.value;
       chart.update();
@@ -244,6 +248,7 @@ div.clip_memo {
       $(e.target).prev("div").toggle();
     });
     $(document).on("click", ".up_clip", (e) => {
+      if (typeof window !== 'undefined' && window.g_Chart !== chart) return;
       const row = e.target.closest("tr");
       if (row.previousElementSibling) {
         const index = row.rowIndex - 1;
@@ -254,6 +259,7 @@ div.clip_memo {
       }
     });
     $(document).on("click", ".down_clip", (e) => {
+      if (typeof window !== 'undefined' && window.g_Chart !== chart) return;
       const row = e.target.closest("tr");
       if (row.nextElementSibling) {
         const index = row.rowIndex - 1;
@@ -264,6 +270,7 @@ div.clip_memo {
       }
     });
     $(document).on("click", ".remove_clip", (e) => {
+      if (typeof window !== 'undefined' && window.g_Chart !== chart) return;
       const row = e.target.closest("tr");
       const index = row.rowIndex - 1;
       data.labels.pop();


### PR DESCRIPTION
【修正内容】
1. CSaveController.js: reload_history_table の for ループで `i` が未宣言 → `for (let i = 0; ...)` に修正（ESM strict mode での ReferenceError）

2. calchistory.js / CSaveController.js: datasets[0].metadata の初期化漏れ → data 初期化時に `metadata: []` を追加 → flip_clip が空データで呼ばれた際の TypeError を防止

3. calchistory.js / CSaveController.js: URLロード後の重複ハンドラ干渉 → $(document).on() によるイベント委譲ハンドラが両ファイルで二重登録される → calchistory.js でチャート作成直後に window.g_Chart = chart を設定し 各ハンドラ先頭で window.g_Chart !== chart の場合スキップするガードを追加 → CSaveController.js 側にも同ガードと row の null チェックを追加 （dewindow マージ時は window.g_Chart → ESM import の g_Chart に読み替え）