### PR TITLE
feat: 性能カスタマイズ（攻撃関連）に「命中物理攻撃で与えるダメージ+◯%」を追加

### DIFF
--- a/ro4/m/js/CSaveDataManager.js
+++ b/ro4/m/js/CSaveDataManager.js
@@ -1016,6 +1016,7 @@ export class CSaveDataManager {
 		spliceArray.push(g_confDataCustomStatusMIG[27]);
 		spliceArray.push(g_confDataSpecMIG[0][0][26]);
 		g_confDataCustomAtk.splice(1, spliceArray.length, ...spliceArray);
+		g_confDataCustomAtk.splice(27, 1, g_confDataSpecMIG[0][0][53]);
 
 		spliceArray = g_confDataCustomStatusMIG.slice(30, 32);
 		spliceArray.push(g_confDataSpecMIG[1][2][14]);

--- a/ro4/m/js/global.js
+++ b/ro4/m/js/global.js
@@ -104,8 +104,8 @@ export function ResetConfDataAllMIG (bAsOnLoad) {
 	g_confDataCustomStatusMIG = Array(46).fill(0);
 	g_confDataCustomSpecStatusMIG = Array(12).fill(0);
 	g_confDataSpecMIG = [
-		[Array(53).fill(0), Array(53).fill(0), Array(53).fill(0)],
-		[Array(53).fill(0), Array(53).fill(0), Array(53).fill(0)],
+		[Array(54).fill(0), Array(54).fill(0), Array(54).fill(0)],
+		[Array(54).fill(0), Array(54).fill(0), Array(54).fill(0)],
 	];
 	g_confDataCustomSkillMIG = Array(12).fill(0);
 	if (typeof window !== 'undefined') {

--- a/ro4/m/js/savedata/CSaveDataConst.js
+++ b/ro4/m/js/savedata/CSaveDataConst.js
@@ -1407,6 +1407,16 @@ export class CSaveDataConst {
 	 */
 	static propNameKiriEffect = "kiriEffect";
 
+	/**
+	 * プロパティ名：命中物理攻撃ダメージ上昇（符号）.
+	 */
+	static propNameSpecDamageUpExcludingCriticalSign = "specDamageUpExcludingCriticalSign";
+
+	/**
+	 * プロパティ名：命中物理攻撃ダメージ上昇.
+	 */
+	static propNameSpecDamageUpExcludingCritical = "specDamageUpExcludingCritical";
+
 
 
 	/**

--- a/ro4/m/js/savedata/CSaveDataUnitCharaConfSpecialize.js
+++ b/ro4/m/js/savedata/CSaveDataUnitCharaConfSpecialize.js
@@ -1,5 +1,6 @@
 import { CSaveDataUnitBase } from './CSaveDataUnitBase.js';
 import { CSaveDataConst } from './CSaveDataConst.js';
+import { CSaveDataPropInfo } from './CSaveDataPropInfo.js';
 /**
  * 「性能カスタマイズ（特化）」情報クラス
  *  TODO: 今は存在しない設定欄なので使われているのか確認が必要
@@ -17,7 +18,19 @@ export class CSaveDataUnitCharaConfSpecialize extends CSaveDataUnitBase {
      * バージョン番号.
      */
     static get version () {
-        return 1;
+        return 2;
+    }
+
+    // オーバーライドされた parse 関数
+    parse (dataText, bitOffset) {
+        let nextOffset = super.parse(dataText, bitOffset);
+        if (this.getProp(CSaveDataConst.propNameVersion) == 1n) {
+            this.propInfoMap.delete(CSaveDataConst.propNameParseCtrlFlag);
+            this.propInfoMap.set(CSaveDataConst.propNameParseCtrlFlag, new CSaveDataPropInfo(CSaveDataConst.propNameParseCtrlFlag, 104));
+            this.parsedMap.clear();
+            nextOffset = super.parse(dataText, bitOffset);
+        }
+        return nextOffset;
     }
 
     /**
@@ -132,6 +145,8 @@ export class CSaveDataUnitCharaConfSpecialize extends CSaveDataUnitBase {
             CSaveDataConst.propNameSpecPlayerAll,
             CSaveDataConst.propNameIgnoreDefenceRaceAll,
             CSaveDataConst.propNameKiriEffect,
+            CSaveDataConst.propNameSpecDamageUpExcludingCriticalSign,
+            CSaveDataConst.propNameSpecDamageUpExcludingCritical,
         ];
     }
 
@@ -150,7 +165,7 @@ export class CSaveDataUnitCharaConfSpecialize extends CSaveDataUnitBase {
         // プロパティ定義情報の登録
         this.registerPropInfo(CSaveDataConst.instanceKind, 6);
         this.registerPropInfo(CSaveDataConst.propNameSubInvalidateSettings, 1);
-        this.registerPropInfo(CSaveDataConst.propNameParseCtrlFlag, 104);
+        this.registerPropInfo(CSaveDataConst.propNameParseCtrlFlag, 106);
         this.registerPropInfo(CSaveDataConst.propNameSpecDamageSign, 1);
         this.registerPropInfo(CSaveDataConst.propNameSpecDamage, CSaveDataConst.propBitsMaxAbs500);
         this.registerPropInfo(CSaveDataConst.propNameSpecCriticalDamageSign, 1);
@@ -255,6 +270,8 @@ export class CSaveDataUnitCharaConfSpecialize extends CSaveDataUnitBase {
         this.registerPropInfo(CSaveDataConst.propNameSpecPlayerAll, CSaveDataConst.propBitsMaxAbs500);
         this.registerPropInfo(CSaveDataConst.propNameIgnoreDefenceRaceAll, CSaveDataConst.propBitsMaxAbs100);
         this.registerPropInfo(CSaveDataConst.propNameKiriEffect, 1);
+        this.registerPropInfo(CSaveDataConst.propNameSpecDamageUpExcludingCriticalSign, 1);
+        this.registerPropInfo(CSaveDataConst.propNameSpecDamageUpExcludingCritical, CSaveDataConst.propBitsMaxAbs500);
     }
 
     /**

--- a/ro4/m/js/savedata/CSaveDataUnitParse.js
+++ b/ro4/m/js/savedata/CSaveDataUnitParse.js
@@ -475,7 +475,7 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 		[dataTextWork, bitOffset] = saveDataUnit.convertFromOldFormat(dataTextWork, bitOffset,
 			CSaveDataConst.specKindAttackPhysical,
 			((saveDataArrayOld[1610] > 0) ? 1 : 0),
-			((1n << 104n) - 1n),
+			((1n << 106n) - 1n),
 
 			...(convertedArrayAtk[5].flat()),
 			0, 0,
@@ -488,7 +488,8 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 			...(new Array(4).fill(0)), ...(convertedArrayAtk[9].flat()),
 			...(new Array(4).fill(0)), 0, 0,
 			convertedArrayAtk[12][1],
-			0
+			0,
+			...(convertedArrayAtk[27].flat())
 		);
 
 		//--------------------------------
@@ -498,7 +499,7 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 		[dataTextWork, bitOffset] = saveDataUnit.convertFromOldFormat(dataTextWork, bitOffset,
 			CSaveDataConst.specKindAttackMagical,
 			((saveDataArrayOld[1610] > 0) ? 1 : 0),
-			((1n << 104n) - 1n),
+			((1n << 106n) - 1n),
 
 			...(convertedArrayAtk[14].flat()),
 			0, 0,
@@ -511,7 +512,8 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 			...(new Array(4).fill(0)), 0, 0,
 			...(new Array(4).fill(0)), 0, 0,
 			convertedArrayAtk[19][1],
-			0
+			0,
+			0, 0
 		);
 
 		//--------------------------------
@@ -521,7 +523,7 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 		[dataTextWork, bitOffset] = saveDataUnit.convertFromOldFormat(dataTextWork, bitOffset,
 			CSaveDataConst.specKindAttackAny,
 			((saveDataArrayOld[1610] > 0) ? 1 : 0),
-			((1n << 104n) - 1n),
+			((1n << 106n) - 1n),
 
 			0, 0,
 			...(convertedArrayAtk[10].flat()),
@@ -534,7 +536,8 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 			...(new Array(6).fill(0)),
 			...(new Array(4).fill(0)), ...(convertedArrayAtk[20].flat()),
 			0,
-			0
+			0,
+			0, 0
 		);
 
 		//--------------------------------
@@ -544,7 +547,7 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 		[dataTextWork, bitOffset] = saveDataUnit.convertFromOldFormat(dataTextWork, bitOffset,
 			CSaveDataConst.specKindDefencekAny,
 			((saveDataArrayOld[1640] > 0) ? 1 : 0),
-			((1n << 104n) - 1n),
+			((1n << 106n) - 1n),
 
 			0, 0,
 			0, 0,
@@ -557,7 +560,8 @@ export class CSaveDataUnitParse extends CSaveDataUnitBase {
 			0, 0, ...(convertedArrayDef[7].flat()), 0, 0,
 			...(new Array(4).fill(0)), ...(convertedArrayDef[8].flat()),
 			0,
-			0
+			0,
+			0, 0
 		);
 
 		//--------------------------------

--- a/roro/m/js/CCharaConfCustomAtk.js
+++ b/roro/m/js/CCharaConfCustomAtk.js
@@ -443,6 +443,20 @@ export function CCharaConfCustomAtk(confArray) {
 
 
 
+		CCharaConfCustomAtk.CONF_ID_DAMAGE_UP_EXCLUDING_CRITICAL = confId;
+		confData = [
+			confId,
+			CConfBase.ConfText("命中物理攻撃で与えるダメージ+◯%"),
+			CConfBase.ConfControlType(CONTROL_TYPE_SELECTBOX_PERCENT),
+			CConfBase.ConfDefaultValue(0),
+			CConfBase.ConfMinValue(-300),
+			CConfBase.ConfMaxValue(300)
+		];
+		this.confDataObj[confId] = confData;
+		confId++;
+
+
+
 		//----------------------------------------------------------------
 		// データ定義数チェック
 		//----------------------------------------------------------------
@@ -486,6 +500,7 @@ export function CCharaConfCustomAtk(confArray) {
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_PHYSICAL_DAMAGE_UP_BOSS_AND_NOT_BOSS];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_LONGRANGE_DAMAGE_UP];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_CRITICAL_DAMAGE_UP];
+		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_DAMAGE_UP_EXCLUDING_CRITICAL];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_PHYSICAL_DAMAGE_UP_ELM];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_PERFECT_ATTACK];
 		confDataOBJSorted[confDataOBJSorted.length] = this.confDataObj[CCharaConfCustomAtk.CONF_ID_IGNORE_DEF_RACE_ALL];

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -8971,6 +8971,11 @@ export function StAllCalc(){
 			n_tok[ITEM_SP_PHYSICAL_DAMAGE_UP] += confval;
 		}
 
+		// 命中物理攻撃で与えるダメージ + ◯%
+		confval = g_objCharaConfCustomAtk.GetConf(CCharaConfCustomAtk.CONF_ID_DAMAGE_UP_EXCLUDING_CRITICAL);
+		if (confval != 0) {
+			n_tok[ITEM_SP_DAMAGE_UP_EXCLUDING_CRITICAL] += confval;
+		}
 		// クリティカル攻撃で与えるダメージ + ◯% を適用する
 		n_tok[ITEM_SP_CRITICAL_DAMAGE_UP] = getCriticalDamageRate();
 

--- a/tests/vitest.integration.config.ts
+++ b/tests/vitest.integration.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
         environment: 'node',
         globals: true,
         include: ['integration/**/*.test.ts', 'integration/**/*.test.js'],
+        exclude: ['integration/**/staging-vs-prod.test.ts'],
         testTimeout: 60000,
         hookTimeout: 30000,
     },


### PR DESCRIPTION
能力コード ITEM_SP_DAMAGE_UP_EXCLUDING_CRITICAL に対応するUI入力欄を追加し、計算式への反映（foot.js）とセーブ・ロード（CSaveDataUnitCharaConfSpecialize v2）を実装した。

- CCharaConfCustomAtk: CONF_ID_DAMAGE_UP_EXCLUDING_CRITICAL（confId=27、±300%）定義
- foot.js: GetConf → n_tok[ITEM_SP_DAMAGE_UP_EXCLUDING_CRITICAL] 加算（クリ以外の物理攻撃に適用済みの ApplyPhysicalDamageUpExcludingCritical が読み取る）
- CSaveDataUnitCharaConfSpecialize: version 1→2、ParseCtrlFlag 104→106bit、新 prop 追加、version 1 データの後方互換 parse migration
- CSaveDataUnitParse: translateFromOldFormat の全 specialize ブロック（物理/魔法/汎用攻撃/防御）に新 prop の引数追加
- global.js: g_confDataSpecMIG 配列サイズ 53→54
- CSaveDataManager: g_confDataSpecMIG[0][0][53] → g_confDataCustomAtk[27] のロード時マッピング追加