### PR TITLE
fix: スロットモードボタン往復クラッシュと別ブランチセーブデータでのカード参照クラッシュを修正

### DIFF
--- a/ro4/m/js/eventsetup.js
+++ b/ro4/m/js/eventsetup.js
@@ -42,7 +42,7 @@ wire('OBJID_BUTTON_OPT_IN_SAVEDATA',      'click', () => optInSavedata());
 
 // クイック設定・スロット切替
 wire('OBJID_QUICK_CONTROL_EXTRACT_CHECKBOX', 'click', OnClickQuickControlSW);
-wire('OBJID_SLOT_MODE_BUTTON',               'click', OnClickSlotModeButton);
+wire('OBJID_SLOT_MODE_BUTTON',               'click', () => OnClickSlotModeButton());
 
 // アクセサリコピー
 wire('OBJID_ACCESSORY_1_COPY', 'click', () => copyAccs(1, 2));

--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -961,7 +961,8 @@ export function ClearEnchantOnChangeEquip(eqpRgnId, itemId) {
 			cardRgnId = cardRegionIdArrayToClear[slotidx];
 
 			// 設定状況をクリア
-			if (CardObjNew[n_A_card[cardRgnId]][CARD_DATA_INDEX_KIND] == CARD_KIND_ENCHANT) {
+			const _cardEntry = CardObjNew[n_A_card[cardRgnId]];
+			if (_cardEntry && _cardEntry[CARD_DATA_INDEX_KIND] == CARD_KIND_ENCHANT) {
 				n_A_card[cardRgnId] = CARD_ID_NONE;
 			}
 		}

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -29111,6 +29111,8 @@ export function GetEquippedSPSubSPCardAndElse(spid, invalidCardIdArray, bListUp)
 		// 装備中のカードデータから、カードデータを取得
 		cardId = n_A_card[cardRegionId];
 		cardData = CardObjNew[cardId];
+		// 別ブランチ等で追加されたカードIDが現在のデータに存在しない場合はスキップ
+		if (!cardData) continue;
 
 		// 効果が無効の装備でないかを検査
 		if (invalidCardIdArray) {

--- a/tests/integration/calcx.test.ts
+++ b/tests/integration/calcx.test.ts
@@ -702,6 +702,27 @@ describe('ro4/m/calcx.html 起動テスト', () => {
         });
         expect(errors, formatErrorMsg('セーブデータ読み込み中', errors)).toHaveLength(0);
     });
+
+    // スロットモードボタンを2回クリックしてカード⇔ランダムオプション切替を往復する。
+    // eventsetup.js で wire(id, 'click', OnClickSlotModeButton) と直接渡すと
+    // MouseEvent が jobId に渡り JobMap.getById(MouseEvent) → undefined → TypeError が
+    // 発生するリグレッションを検出する。
+    it('スロットモードボタン カード→ランダムオプション→カード 往復で未捕捉 JS 例外が発生しない', async () => {
+        const errors = await collectPageErrors(browser, async (page) => {
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, {
+                waitUntil: 'networkidle',
+                timeout: 60000,
+            });
+            await page.waitForTimeout(500);
+            // 1回目クリック: カードモード → ランダムオプションモード
+            await page.click('#OBJID_SLOT_MODE_BUTTON');
+            await page.waitForTimeout(300);
+            // 2回目クリック: ランダムオプションモード → カードモード（ここで jobData が undefined になっていた）
+            await page.click('#OBJID_SLOT_MODE_BUTTON');
+            await page.waitForTimeout(300);
+        });
+        expect(errors, formatErrorMsg('スロットモードボタン往復操作中', errors)).toHaveLength(0);
+    });
 });
 
 // ─── スイート 2: URL セーブ/ロード 往復テスト（新形式のみ）────────────────────


### PR DESCRIPTION
## スロットモードボタン (#1)

eventsetup.js で wire('OBJID_SLOT_MODE_BUTTON', 'click', OnClickSlotModeButton) と ハンドラを直接渡していたため、ブラウザが MouseEvent を jobId 引数として渡してしまい、 JobMap.getById(MouseEvent) が undefined を返して BuildUpCostumeSlotsCostume 内でクラッシュしていた。

- eventsetup.js: () => OnClickSlotModeButton() でラップして MouseEvent が渡らないよう修正
- 回帰テスト: integration (calcx) にスロットモード往復テストを追加

根本原因は 03860d13（window compat block 除去作業1）で HTML の onclick 属性を eventsetup.js の wire に移行した際にラムダ包みが省略されたこと。 昨日の 2 コミット自体は直接の原因ではないが、そのタイミングで発覚。

## 別ブランチセーブデータでのカード参照クラッシュ (#2)

別ブランチで追加されたカード ID を含む URL をロードすると CardObjNew[cardId] === undefined になり、GetEquippedSPSubSPCardAndElse や equip.js の enchant チェックがクラッシュしていた。

- foot.js: GetEquippedSPSubSPCardAndElse に if (!cardData) continue; ガードを追加
- equip.js: enchant クリア判定に !_cardEntry ガードを追加