### PR TITLE
fix: スーパーノービスの魂をONにしても装備制限が解除されないバグを修正

### DIFF
--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -57,9 +57,24 @@ import { GetObjectIdRndOptKind, GetObjectIdRndOptValue, RebuildRndOptSelect, Set
 import { CItemInfoManager } from './CItemInfoManager.js';
 import { g_extraInfoDataBridge } from './CExtraInfoDataBridge.js';
 // === END AUTO-GENERATED IMPORTS ===
-var g_bSuperNoviceFullWeapon;
+// スパノビの魂による装備制限解除フラグ。本モジュールが所有者。
+// 書き手は foot.js の RefreshSuperNoviceFullWeapon（SetSuperNoviceFullWeapon 経由）と
+// 当モジュールの changeJobSettings（職変更時に undefined へリセット）。
+// ESM 移行(#1394)で foot.js 側にも別個の宣言ができてしまい状態が分断していたため、
+// 単一の所有者へ統一して live binding で共有する。
+export var g_bSuperNoviceFullWeapon;
 var n_A_WeaponType;
 var n_A_Weapon2Type;
+
+/**
+ * スパノビの魂による装備制限解除フラグを設定する。
+ * foot.js など他モジュールは import したライブバインディングを直接代入できないため、
+ * このセッター経由で更新する。
+ * @param {boolean|undefined} bFull
+ */
+export function SetSuperNoviceFullWeapon(bFull) {
+	g_bSuperNoviceFullWeapon = bFull;
+}
 
 /**
  * ステータスや装備などを初期化して職業変更する

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -253,8 +253,8 @@ import {
 import { COSTUME_ID_BEGINNER_BO, CostumeOBJ } from './costume.dat.js';
 import {
          ClearEquipAll, InitEquipDefaultAll, IsLongRange, OnChangeArmsTypeRight,
-         OnChangeCard, OnChangeEquip, RebuildArmorsSelect,
-         UpdateStatefullDataOnChangeEquip, changeJobSettings
+         OnChangeCard, OnChangeEquip, RebuildArmorsSelect, SetSuperNoviceFullWeapon,
+         UpdateStatefullDataOnChangeEquip, changeJobSettings, g_bSuperNoviceFullWeapon
 } from './equip.js';
 import { zokusei } from './etc.js';
 import { ClearCardSlotAll, SetCardSlotEnabilityAll } from './hmcard.js';
@@ -930,7 +930,8 @@ let g_ITEM_SP_VIT_PLUS_PLANE_value_forCalcData = 0;
 let g_ITEM_SP_INT_PLUS_PLANE_value_forCalcData = 0;
 let g_ITEM_SP_DEX_PLUS_PLANE_value_forCalcData = 0;
 let g_ITEM_SP_LUK_PLUS_PLANE_value_forCalcData = 0;
-let g_bSuperNoviceFullWeapon = undefined;
+// g_bSuperNoviceFullWeapon は equip.js が所有（import 済みのライブバインディング）。
+// 書き込みは SetSuperNoviceFullWeapon 経由で行う。
 let g_objMobConfInput = null;
 
 export function RefreshSuperNoviceFullWeapon(bFull) {
@@ -965,7 +966,7 @@ export function RefreshSuperNoviceFullWeapon(bFull) {
 	}
 
 
-	g_bSuperNoviceFullWeapon = bFull;
+	SetSuperNoviceFullWeapon(bFull);
 
 
 	// 現在の装備状況をもとに、設定変更後の装備可否を判定し、ItemID を特定しておく
@@ -1197,6 +1198,13 @@ export function RefreshSuperNoviceFullWeapon(bFull) {
 
 		OnChangeCard(-1);
 	}
+
+	// 武器・防具セレクトボックスの option をプログラム的に作り直したため、
+	// ラップしている TomSelect の表示を再初期化して同期する。
+	// （通常のジョブ/武器種変更は select の 'change' イベント経由で
+	// tom-select.custom.js が自動再初期化するが、魂トグルは change を発火せず
+	// 直接 option を再構築するため、ここで明示的に呼ぶ必要がある）
+	LoadTomSelect();
 
 }
 
@@ -30930,7 +30938,6 @@ if (typeof window !== 'undefined') {
         g_ITEM_SP_INT_PLUS_PLANE_value_forCalcData: { get: () => g_ITEM_SP_INT_PLUS_PLANE_value_forCalcData, set: v => { g_ITEM_SP_INT_PLUS_PLANE_value_forCalcData = v; }, configurable: true },
         g_ITEM_SP_DEX_PLUS_PLANE_value_forCalcData: { get: () => g_ITEM_SP_DEX_PLUS_PLANE_value_forCalcData, set: v => { g_ITEM_SP_DEX_PLUS_PLANE_value_forCalcData = v; }, configurable: true },
         g_ITEM_SP_LUK_PLUS_PLANE_value_forCalcData: { get: () => g_ITEM_SP_LUK_PLUS_PLANE_value_forCalcData, set: v => { g_ITEM_SP_LUK_PLUS_PLANE_value_forCalcData = v; }, configurable: true },
-        g_bSuperNoviceFullWeapon: { get: () => g_bSuperNoviceFullWeapon, set: v => { g_bSuperNoviceFullWeapon = v; }, configurable: true },
         g_objMobConfInput: { get: () => g_objMobConfInput, set: v => { g_objMobConfInput = v; }, configurable: true },
         g_intervalFunctionSimulateCastTime: { get: () => g_intervalFunctionSimulateCastTime, set: v => { g_intervalFunctionSimulateCastTime = v; }, configurable: true },
         g_castProgressInterval: { get: () => g_castProgressInterval, set: v => { g_castProgressInterval = v; }, configurable: true },

--- a/tests/integration/calcx.test.ts
+++ b/tests/integration/calcx.test.ts
@@ -411,6 +411,76 @@ describe('ro4/m/calcx.html 起動テスト', () => {
         expect(errors, formatErrorMsg('A1パッシブスキル欄操作中', errors)).toHaveLength(0);
     });
 
+    // スーパーノービスの魂 ON で装備制限が解除されることを確認する。
+    // 回帰背景: スパノビの魂フラグ g_bSuperNoviceFullWeapon は foot.js（書き手・
+    // RefreshSuperNoviceFullWeapon）と equip.js（読み手・RebuildArmorsSelect 等）で
+    // 共有される必要があるが、ESM 移行(#1394)で両ファイルに別個のモジュールローカル変数が
+    // 宣言され状態が分断していた。結果 foot.js が値を立てても equip.js 側は undefined のままで
+    // 「魂を ON にしても効果が出ない」バグになっていた。
+    // ユニットでは foot.js が巨大で import できずクロスモジュール結線を検証できないため
+    // 実機（calcx.html）で「魂 ON → 頭装備の選択肢が増える」ことを確認する。
+    it('スーパーノービスの魂 ON で頭装備の選択肢が解禁される（魂フラグのクロスモジュール同期）', async () => {
+        let result: { found: boolean; headBefore: number; headAfter: number; tsBefore: number; tsAfter: number } =
+            { found: false, headBefore: 0, headAfter: 0, tsBefore: -1, tsAfter: -1 };
+        const errors = await collectPageErrors(browser, async (page) => {
+            page.on('dialog', (dialog) => dialog.dismiss().catch(() => {}));
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, { waitUntil: 'networkidle', timeout: 60000 });
+            await page.waitForFunction(() => {
+                const j = document.getElementById('OBJID_SELECT_JOB') as HTMLSelectElement | null;
+                return !!(j && j.options.length > 1);
+            }, { timeout: 15000 }).catch(() => {});
+            await page.waitForTimeout(300);
+
+            result = await page.evaluate(async () => {
+                const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+                const fail = { found: false, headBefore: 0, headAfter: 0 };
+                const job = document.getElementById('OBJID_SELECT_JOB') as
+                    (HTMLSelectElement & { tomselect?: { setValue(v: string): void } }) | null;
+                if (!job) return fail;
+                // スーパーノービス系の職を選ぶ（魂スキルを持つ職）
+                const snOpt = Array.from(job.options).find(
+                    (o) => o.text.includes('スーパーノービス') && o.value && o.value !== '0');
+                if (!snOpt) return fail;
+                if (job.tomselect) job.tomselect.setValue(snOpt.value);
+                else { job.value = snOpt.value; job.dispatchEvent(new Event('change', { bubbles: true })); }
+                await sleep(500);
+                // A1（職固有自己支援）欄を展開して魂スキルの select を生成させる
+                const sw = document.querySelector<HTMLInputElement>('[name="A1_SKILLSW"]');
+                if (sw && !sw.checked) { sw.click(); await sleep(500); }
+                // 魂スキルの select は inline onClick に RefreshSuperNoviceFullWeapon を持つ
+                const soulSel = document.querySelector<HTMLSelectElement>('[onclick*="RefreshSuperNoviceFullWeapon"]');
+                const headSel = document.getElementById('OBJID_HEAD_TOP') as
+                    (HTMLSelectElement & { tomselect?: { options: Record<string, unknown> } }) | null;
+                if (!soulSel || !headSel) return fail;
+                const tsCount = () => headSel.tomselect ? Object.keys(headSel.tomselect.options).length : -1;
+                const headBefore = headSel.options.length;
+                const tsBefore = tsCount();
+                // 魂を ON にする（value=1 + inline onClick 発火 → RefreshSuperNoviceFullWeapon(true)）
+                soulSel.value = '1';
+                soulSel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+                await sleep(300);
+                const headAfter = headSel.options.length;
+                const tsAfter = tsCount();
+                return { found: true, headBefore, headAfter, tsBefore, tsAfter };
+            });
+        });
+        expect(result.found, 'スーパーノービス職/魂スキルの select を操作できなかった（テスト前提の不成立）').toBe(true);
+        // 魂 ON で職業制限のある頭装備が解禁され、選択肢数が増える（生の <select>）。
+        // バグ時は equip.js 側のフラグが更新されず増えない（headAfter === headBefore）。
+        expect(
+            result.headAfter,
+            `魂 ON で頭装備の選択肢が増えていない (before=${result.headBefore}, after=${result.headAfter})`,
+        ).toBeGreaterThan(result.headBefore);
+        // TomSelect でラップされた表示も再構築後に同期され、増えた選択肢を反映する。
+        // 同期漏れ時は TomSelect 内部の option 数が更新されず tsAfter === tsBefore のまま。
+        expect(result.tsBefore, 'OBJID_HEAD_TOP が TomSelect 化されていない（テスト前提の不成立）').toBeGreaterThan(0);
+        expect(
+            result.tsAfter,
+            `魂 ON 後に TomSelect 表示が同期されていない (tsBefore=${result.tsBefore}, tsAfter=${result.tsAfter}, 生select after=${result.headAfter})`,
+        ).toBe(result.headAfter);
+        expect(errors, formatErrorMsg('スパノビの魂 ON 操作中', errors)).toHaveLength(0);
+    });
+
     // OBJID_MONSTER_MAP_AREA のカテゴリ変更でマップリストがカスケード更新されることを確認。
     // dewindow フェーズで CCustomSelectBase の onchange 属性を addEventListener に切り替えた後、
     // カテゴリ変更 → マップリスト更新 / マップ変更 → モンスターリスト更新 の連鎖が壊れていないかを確認する。


### PR DESCRIPTION
「スーパーノービスの魂」をONにしても全兜・Lv4武器の装備制限が 解除されない問い合わせに対応。原因は独立した2点。

1. 魂フラグのクロスモジュール分断（ESM移行 #1394 で混入） g_bSuperNoviceFullWeapon が foot.js（書き手）と equip.js（読み手）で 別個のモジュールローカル変数として宣言されており、 RefreshSuperNoviceFullWeapon が foot.js 側を更新しても equip.js 側の 装備判定（RebuildArmorsSelect / RebuildArmsRightSelect）には届かず、 魂ONが無効化されていた。移行前は暗黙のグローバル(window共有)で 機能していた。 → equip.js を単一の所有者に統一。export var + SetSuperNoviceFullWeapon セッターを公開し、foot.js は import したライブバインディングを読み、 書き込みはセッター経由に変更。foot.js 側の重複宣言と死蔵していた window bridge を撤去。

2. TomSelect 表示の同期漏れ（1.の修正で表面化） RefreshSuperNoviceFullWeapon は option を直接作り直すだけで change を 発火しないため、tom-select.custom.js の自動再初期化が走らず、 生 <select> は更新されてもラップしている TomSelect 表示が stale に なっていた（OBJID_HEAD_TOP: 生476→782 に対し表示は476のまま）。 → 再構築の末尾で LoadTomSelect() を明示呼び出しして表示を同期。