### PR TITLE
fix: TomSelect再初期化時のoption末尾移動バグを再修正 (#1482)

### DIFF
--- a/lib/tom-select/tom-select.custom.js
+++ b/lib/tom-select/tom-select.custom.js
@@ -52,31 +52,29 @@ function LoadTomSelectSpecify(select_id) {
             const isEnchant = Array.from(el.options).some(o => o.text.includes('エンチャントなし'));
             if (el.tomselect) {
                 const savedValue = el.value;
-                // ジョブ/武器種変更でオプションが丸ごと再生成された場合、旧 $order で
-                // ソートすると新規オプションがすべて末尾に追いやられ50音順が崩れる。
-                // オプションセットが同一（ユーザーが値を選んだだけ）のときのみ $order
-                // 復元を行い、変化があった場合はゲームロジックが再構築した DOM 順をそのまま使う。
+                // TomSelect の updateOriginalInput() は選択時に <option> を DOM 末尾へ移動する。
+                // ただし destroy() は revertSettings.innerHTML（sync() 前の正しい50音順）を
+                // 自動復元するため、オプションセットが変わっていない場合は destroy() だけで十分。
+                //
+                // オプションセットが変化した場合（ジョブ/武器種変更でゲームロジックが再構築）は
+                // destroy() で古い revertSettings が復元されてしまうため、現在の DOM を退避する。
+                //
+                // 空値 ("") は TomSelect が未選択時にダミーで作る option であり
+                // options dict には含まれないため比較から除外する。
                 const tsOpts = el.tomselect.options;
-                const curVals = new Set(Array.from(el.options).map(o => String(o.value)));
+                const curVals = new Set(Array.from(el.options).map(o => String(o.value)).filter(v => v !== ''));
                 const tsVals  = new Set(Object.keys(tsOpts));
                 const sameSet = curVals.size === tsVals.size &&
                                 [...curVals].every(v => tsVals.has(v) || tsVals.has(encodeURIComponent(v)));
                 if (sameSet) {
-                    // Tom Select の updateOriginalInput() は選択時に <option> を DOM 末尾へ
-                    // appendChild() するため、$order でソートして元の位置に戻す。
-                    Array.from(el.options)
-                        .sort((a, b) => {
-                            const oa = tsOpts[a.value] ?? tsOpts[encodeURIComponent(a.value)];
-                            const ob = tsOpts[b.value] ?? tsOpts[encodeURIComponent(b.value)];
-                            return (oa?.$order ?? Infinity) - (ob?.$order ?? Infinity);
-                        })
-                        .forEach(opt => el.appendChild(opt));
+                    // destroy() が revertSettings.innerHTML（正しい50音順）を復元する。
+                    el.tomselect.destroy();
+                } else {
+                    // ゲームロジックが正しい50音順で再構築済みの DOM を退避・復元する。
+                    const savedHTML = el.innerHTML;
+                    el.tomselect.destroy();
+                    el.innerHTML = savedHTML;
                 }
-                // sameSet が偽の場合：ゲームロジックが正しい50音順で再構築済みなので
-                // 現在の DOM をそのまま savedHTML として使う。
-                const savedHTML = el.innerHTML;
-                el.tomselect.destroy();
-                el.innerHTML = savedHTML;
                 el.value = savedValue;
             }
             if (isEnchant) return;


### PR DESCRIPTION
【バグ】装備品を変更すると選択していた装備がプルダウン末尾に現れる。

【原因】 TomSelect の updateOriginalInput() は選択時に <option> 要素を DOM 末尾へ appendChild() する。従来の修正（$order ソート）は sameSet=true のときのみ機能していたが、以下の2ケースで sameSet が 誤って false と判定され末尾移動が残っていた。

1. TomSelect が未選択時にダミーの <option value=""> を DOM に追加する。 この空値は TomSelect 自身の options dict に含まれないため、 curVals.size > tsVals.size となり sameSet=false に落ちていた。

2. sameSet=false では $order ソートが走らず、TomSelect が汚染した DOM 順のまま savedHTML を保存していた。新しい TomSelect が その HTML を読んで $order を振り直すと選択 option が末尾扱いになる。

【修正】 sameSet=true の場合、destroy() が自動的に revertSettings.innerHTML （= sync() より前に保存された正しい50音順）を復元するため、 innerHTML の保存・$order ソートは不要と判明。

- sameSet=true: destroy() のみ呼ぶ（revertSettings が正しい順序を復元）
- sameSet=false: el.innerHTML をdestroy()前に退避して復元（従来通り）
- curVals 算出時に空値 ("") をフィルタし誤検知を防ぐ