### PR TITLE
feat: 拡張情報表示欄のATK+%にITEM_SP_WEAPON_ATK_UPの値を表示

### DIFF
--- a/roro/m/js/CExtraInfoAreaComponentManager.js
+++ b/roro/m/js/CExtraInfoAreaComponentManager.js
@@ -5494,7 +5494,7 @@ export function CExtraInfoAreaComponentManager () {
 			dispInfoArrayArray = [
 				["MaxHP", ITEM_SP_MAXHP_PLUS, ITEM_SP_MAXHP_UP],
 				["MaxSP", ITEM_SP_MAXSP_PLUS, ITEM_SP_MAXSP_UP],
-				["Atk", ITEM_SP_ATK_PLUS, ITEM_SP_ATK_UP],
+				["Atk/武器攻撃力", ITEM_SP_ATK_PLUS, ITEM_SP_WEAPON_ATK_UP],
 				["Matk", ITEM_SP_MATK_PLUS_TYPE_NOT_WEAPON, ITEM_SP_NONE],
 				["除算Def", ITEM_SP_DEF_PLUS, ITEM_SP_DEF_UP],
 				["除算Mdef", ITEM_SP_MDEF_PLUS, ITEM_SP_MDEF_UP],

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -14631,6 +14631,11 @@ export function StAllCalc(){
 			n_tok[ITEM_SP_WEAPON_ATK_UP] += confval;
 		}
 
+		// 拡張表示用にデータを保存
+		// 土符はグランドクロスに影響を及ぼすが武器攻撃力%UPは影響を及ぼさないので個別に計算している
+		const weapon_atk_up = n_tok[ITEM_SP_WEAPON_ATK_UP] + Math.max(0, 10 * UsedSkillSearch(SKILL_ID_FU_COUNT_OF_FU));
+		CExtraInfoAreaComponentManager.dispDataMap.set(ITEM_SP_WEAPON_ATK_UP, weapon_atk_up);
+
 
 /**
  * ===========================================================================================


### PR DESCRIPTION
武器攻撃力＋○○％の計算結果（n_tok[ITEM_SP_WEAPON_ATK_UP]）をCExtraInfoAreaComponentManager.dispDataMapへ転記してATK+%欄が表示されるように修正。