### PR TITLE
feat: 拡張情報パネルにSTRボーナス表示を追加し、装備変更時に即時反映されるよう修正

### DIFF
--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -512,7 +512,7 @@ import {
          SKILL_ID_ZYURYOKU_CHOSE, SKILL_ID_ZYUTSUSHIKI_KAIHO
 } from '../../../roro/m/js/skill.dat.js';
 import { UsedSkillSearch, n_A_PassSkill3, n_A_PassSkill4, n_A_PassSkill7, n_A_PassSkill8, ID_BUFF_MANUK_ISHI, ID_BUFF_VESPER_HONEY } from './skillstate.js';
-import { g_extraInfoDataBridge } from '../../../roro/m/js/CExtraInfoDataBridge.js';
+import { DISP_DATA_KEY_STRDEX_BONUS, g_extraInfoDataBridge } from '../../../roro/m/js/CExtraInfoDataBridge.js';
 // === END AUTO-GENERATED IMPORTS ===
 
 "use strict";
@@ -16173,6 +16173,10 @@ export function calc() {
 	CCalcDataTextCreator.refBattleData[BATTLE_DATA_INDEX_RANGE_FLAG] = n_Enekyori;
 
 	CCalcDataTextCreator.refBattleData[BATTLE_DATA_INDEX_STRDEX_BONUS] = w_BONUS;
+	// StAllCalc() 内の RefreshDispAreaAll（foot.js）は w_BONUS 確定前に走るため、
+	// ここで再度リフレッシュして拡張情報パネルに最新値を反映する
+	g_extraInfoDataBridge.setDispDataValue?.(DISP_DATA_KEY_STRDEX_BONUS, w_BONUS);
+	g_extraInfoDataBridge.refreshFloatingDispAreaAll?.();
 
 	CCalcDataTextCreator.refBattleData[BATTLE_DATA_INDEX_SIZE_MODIFY] = wCSize;
 	CCalcDataTextCreator.refBattleData[BATTLE_DATA_INDEX_HIT_RATE] = w_HIT;

--- a/roro/m/js/CExtraInfoAreaComponentManager.js
+++ b/roro/m/js/CExtraInfoAreaComponentManager.js
@@ -60,7 +60,7 @@ import {
          SKILL_ID_ZYOKODO
 } from './skill.dat.js';
 import { UsedSkillSearch } from '../../../ro4/m/js/skillstate.js';
-import { g_extraInfoDataBridge } from './CExtraInfoDataBridge.js';
+import { DISP_DATA_KEY_STRDEX_BONUS, g_extraInfoDataBridge } from './CExtraInfoDataBridge.js';
 // === END AUTO-GENERATED IMPORTS ===
 //----------------------------------------------------------------
 // 拡張情報の種類
@@ -5495,6 +5495,7 @@ export function CExtraInfoAreaComponentManager () {
 				["MaxHP", ITEM_SP_MAXHP_PLUS, ITEM_SP_MAXHP_UP],
 				["MaxSP", ITEM_SP_MAXSP_PLUS, ITEM_SP_MAXSP_UP],
 				["Atk/武器攻撃力", ITEM_SP_ATK_PLUS, ITEM_SP_WEAPON_ATK_UP],
+				["Atk(STRボーナス)", DISP_DATA_KEY_STRDEX_BONUS, ITEM_SP_NONE],
 				["Matk", ITEM_SP_MATK_PLUS_TYPE_NOT_WEAPON, ITEM_SP_NONE],
 				["除算Def", ITEM_SP_DEF_PLUS, ITEM_SP_DEF_UP],
 				["除算Mdef", ITEM_SP_MDEF_PLUS, ITEM_SP_MDEF_UP],
@@ -5832,4 +5833,5 @@ CExtraInfoAreaComponentManager.RefreshDispAreaAll = function () {
 
 g_extraInfoDataBridge.clearStoredValueAll = (force) => CExtraInfoAreaComponentManager.ClearStoredValueAll(force);
 g_extraInfoDataBridge.rebuildDispAreaAll = () => CExtraInfoAreaComponentManager.RebuildDispAreaAll();
+g_extraInfoDataBridge.setDispDataValue = (key, value) => CExtraInfoAreaComponentManager.dispDataMap.set(key, value);
 

--- a/roro/m/js/CExtraInfoAreaComponentManager.js
+++ b/roro/m/js/CExtraInfoAreaComponentManager.js
@@ -5494,7 +5494,7 @@ export function CExtraInfoAreaComponentManager () {
 			dispInfoArrayArray = [
 				["MaxHP", ITEM_SP_MAXHP_PLUS, ITEM_SP_MAXHP_UP],
 				["MaxSP", ITEM_SP_MAXSP_PLUS, ITEM_SP_MAXSP_UP],
-				["Atk", ITEM_SP_ATK_PLUS, ITEM_SP_ATK_UP],
+				["Atk/武器攻撃力", ITEM_SP_ATK_PLUS, ITEM_SP_WEAPON_ATK_UP],
 				["Matk", ITEM_SP_MATK_PLUS_TYPE_NOT_WEAPON, ITEM_SP_NONE],
 				["除算Def", ITEM_SP_DEF_PLUS, ITEM_SP_DEF_UP],
 				["除算Mdef", ITEM_SP_MDEF_PLUS, ITEM_SP_MDEF_UP],

--- a/roro/m/js/CExtraInfoDataBridge.js
+++ b/roro/m/js/CExtraInfoDataBridge.js
@@ -13,4 +13,13 @@ export const g_extraInfoDataBridge = {
     clearStoredValueAll: null,
     /** @type {(() => void)|null} */
     rebuildDispAreaAll: null,
+    /** @type {((key: string, value: number) => void)|null} */
+    setDispDataValue: null,
+    /** @type {(() => void)|null} */
+    refreshFloatingDispAreaAll: null,
 };
+
+/**
+ * dispDataMap 用キー: STRボーナス（ITEM_SP_* ではなく、STR/DEX値から導出される計算上の固定加算のため専用キーとする）.
+ */
+export const DISP_DATA_KEY_STRDEX_BONUS = "STRDEX_BONUS";

--- a/roro/m/js/CFloatingInfoAreaComponentManager.js
+++ b/roro/m/js/CFloatingInfoAreaComponentManager.js
@@ -1,5 +1,6 @@
 import { CGlobalConstManager } from './CGlobalConstManager.js';
 import { CExtraInfoAreaComponentManager } from './CExtraInfoAreaComponentManager.js';
+import { g_extraInfoDataBridge } from './CExtraInfoDataBridge.js';
 // === AUTO-GENERATED IMPORTS ===
 import './chara.js';
 import { g_timeItemConf } from '../../../ro4/m/js/global.js';
@@ -494,6 +495,8 @@ CFloatingInfoAreaComponentManager.RefreshDispAreaAll = function () {
 		CFloatingInfoAreaComponentManager.RefreshDispArea(idx);
 	}
 }
+
+g_extraInfoDataBridge.refreshFloatingDispAreaAll = () => CFloatingInfoAreaComponentManager.RefreshDispAreaAll();
 
 /**
  * 表示エリアを再表示する.

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -14631,6 +14631,11 @@ export function StAllCalc(){
 			n_tok[ITEM_SP_WEAPON_ATK_UP] += confval;
 		}
 
+		// 拡張表示用にデータを保存
+		// 土符はグランドクロスに影響を及ぼすが武器攻撃力%UPは影響を及ぼさないので個別に計算している
+		const weapon_atk_up = n_tok[ITEM_SP_WEAPON_ATK_UP] + Math.max(0, 10 * UsedSkillSearch(SKILL_ID_FU_COUNT_OF_FU));
+		CExtraInfoAreaComponentManager.dispDataMap.set(ITEM_SP_WEAPON_ATK_UP, weapon_atk_up);
+
 
 /**
  * ===========================================================================================

--- a/tests/roro/CExtraInfoAreaComponentManager.test.ts
+++ b/tests/roro/CExtraInfoAreaComponentManager.test.ts
@@ -50,9 +50,17 @@ import {
     GetExtraInfoText,
     CExtraInfoAreaComponentManager,
 } from '@roro/CExtraInfoAreaComponentManager.js';
+import { DISP_DATA_KEY_STRDEX_BONUS, g_extraInfoDataBridge } from '@roro/CExtraInfoDataBridge.js';
 
 describe('CExtraInfoAreaComponentManager.js', () => {
     describe('エクスポート確認', () => {
         it('dispDataMap が Map', () => expect(CExtraInfoAreaComponentManager.dispDataMap instanceof Map).toBe(true));
+    });
+
+    describe('STRボーナス（dispDataMap 連携）', () => {
+        it('g_extraInfoDataBridge.setDispDataValue は head.js 等から dispDataMap への書き込みを中継する', () => {
+            g_extraInfoDataBridge.setDispDataValue(DISP_DATA_KEY_STRDEX_BONUS, 42);
+            expect(CExtraInfoAreaComponentManager.dispDataMap.get(DISP_DATA_KEY_STRDEX_BONUS)).toBe(42);
+        });
     });
 });

--- a/tests/roro/CFloatingInfoAreaComponentManager.test.ts
+++ b/tests/roro/CFloatingInfoAreaComponentManager.test.ts
@@ -31,8 +31,14 @@ vi.mock('@roro/monster.dat.js', async (importActual) => {
 
 import '/workspace/ratorio/roro/m/js/CGlobalConstManager.js';
 import { GetFloatingInfoText, CFloatingInfoAreaInfoUnit, CFloatingInfoAreaComponentManager } from '@roro/CFloatingInfoAreaComponentManager.js';
+import { g_extraInfoDataBridge } from '@roro/CExtraInfoDataBridge.js';
 
 describe('CFloatingInfoAreaComponentManager.js', () => {
-    it.todo('動作テストを追加する');
+    it('g_extraInfoDataBridge.refreshFloatingDispAreaAll は CFloatingInfoAreaComponentManager.RefreshDispAreaAll に中継される', () => {
+        const spy = vi.spyOn(CFloatingInfoAreaComponentManager, 'RefreshDispAreaAll');
+        g_extraInfoDataBridge.refreshFloatingDispAreaAll();
+        expect(spy).toHaveBeenCalledTimes(1);
+        spy.mockRestore();
+    });
 });
 


### PR DESCRIPTION
EXTRA_INFO_EFFECTIVE_SP_KIND_STATUS_EXTRA に head.js の w_BONUS（STR/DEXから
算出される固定ATK加算）を表示する行を追加。ITEM_SP_* enumは装備由来の補正値
専用のため、CExtraInfoDataBridge に専用キー(DISP_DATA_KEY_STRDEX_BONUS)と
中継関数(setDispDataValue)を新設し、head.js→CExtraInfoAreaComponentManagerの
直接importによる循環依存を回避。

また、foot.js の StAllCalc() 内 RefreshDispAreaAll() が w_BONUS 確定前に
実行されるため、装備変更後もSTRボーナス欄が前回値のまま固定される問題が
あった。w_BONUS 確定直後に再リフレッシュ(refreshFloatingDispAreaAll)する
処理を追加し、他の値と同様に即時反映されるよう修正。
