### PR TITLE
被ダメージ計算の改善（設定の永続化・参考リンク分離・最大値表示化）

### DIFF
--- a/ro4/m/calcx.html
+++ b/ro4/m/calcx.html
@@ -1945,6 +1945,7 @@
 <script type="module" src="../../ro4/m/js/CBattleCalcInfo.js"></script>
 <script type="module" src="../../ro4/m/js/CBattleCalcResult.js"></script>
 <script type="module" src="../../ro4/m/js/CBattleCalcResultAll.js"></script>
+<script type="module" src="../../ro4/m/js/CReceivedDamageConfManager.js"></script>
 <script type="module" src="../../ro4/m/js/head.js"></script>
 
 <!-- セーブデータ管理系 javascript ファイル -->

--- a/ro4/m/js/CReceivedDamageConfManager.js
+++ b/ro4/m/js/CReceivedDamageConfManager.js
@@ -1,0 +1,187 @@
+/**
+ * 被ダメージ計算設定の永続化管理クラス.
+ * 戦闘結果エリアは再計算のたびに再構築され、被ダメージ計算設定の入力値が
+ * 初期値に戻ってしまうため、設定値をローカルストレージへ保存し、再構築時に復元する。
+ *
+ * 設定の既定値・値域は画面部品の構築コード（head.js）側を唯一の情報源とする。
+ * 保存値がない項目・不正な保存値の項目は画面部品の初期値のまま変更しない。
+ */
+export class CReceivedDamageConfManager {
+
+	/**
+	 * ストレージデータ名（被ダメージ計算設定）.
+	 */
+	static get STORAGE_NAME () {
+		return "RRTRDC";
+	}
+
+	/**
+	 * データ形式バージョン.
+	 * （フィールドの追加では変更不要。形式自体を変える場合のみ上げる）
+	 */
+	static get VERSION () {
+		return 1;
+	}
+
+	/**
+	 * 永続化対象フィールドの定義.
+	 * 被ダメージ計算設定に項目を追加する場合は、この配列に1行追加する。
+	 * type: "number"＝数値入力（min/max属性の範囲へクランプして復元）
+	 * 　　　"select"＝選択部品（現在の選択肢に存在する値のみ復元）
+	 */
+	static get fieldDefs () {
+		return [
+			{ key: "physicalRatio",   objId: "OBJID_ENEMY_SKILL_RATIO",         type: "number" },
+			{ key: "physicalElement", objId: "OBJID_ENEMY_SKILL_ELEMENT",       type: "select" },
+			{ key: "magicalRatio",    objId: "OBJID_ENEMY_MAGIC_SKILL_RATIO",   type: "number" },
+			{ key: "magicalElement",  objId: "OBJID_ENEMY_MAGIC_SKILL_ELEMENT", type: "select" },
+		];
+	}
+
+	/**
+	 * ローカルストレージから設定を読み込む.
+	 * @returns {Object} 設定オブジェクト（パース失敗・バージョン不一致の場合は空オブジェクト）
+	 */
+	static #loadConf () {
+
+		try {
+			const parsed = JSON.parse(localStorage.getItem(this.STORAGE_NAME));
+
+			if (!parsed || (parsed.version !== this.VERSION)) {
+				return {};
+			}
+
+			return parsed;
+		}
+		catch (e) {
+			return {};
+		}
+	}
+
+	/**
+	 * 保存済みの設定値を画面部品へ復元する.
+	 * （初回の被ダメージ計算より前に呼び出すこと）
+	 */
+	static RestoreToControls () {
+
+		const conf = this.#loadConf();
+
+		for (const fieldDef of this.fieldDefs) {
+
+			const objControl = document.getElementById(fieldDef.objId);
+
+			// 画面部品がない、または保存値がない項目は変更しない
+			if (!objControl || !(fieldDef.key in conf)) {
+				continue;
+			}
+
+			this.#restoreValue(objControl, fieldDef.type, conf[fieldDef.key]);
+		}
+	}
+
+	/**
+	 * 単一の画面部品へ保存値を復元する.
+	 * @param {HTMLElement} objControl 画面部品
+	 * @param {string} type フィールド種別（"number" or "select"）
+	 * @param {*} value 保存値
+	 */
+	static #restoreValue (objControl, type, value) {
+
+		switch (type) {
+
+		case "number": {
+
+			let valueWork = Number(value);
+			if (!Number.isFinite(valueWork)) {
+				return;
+			}
+
+			// min / max 属性が定義されていれば、その範囲へクランプする
+			const valueMin = Number(objControl.getAttribute("min"));
+			const valueMax = Number(objControl.getAttribute("max"));
+			if (Number.isFinite(valueMin)) {
+				valueWork = Math.max(valueMin, valueWork);
+			}
+			if (Number.isFinite(valueMax)) {
+				valueWork = Math.min(valueMax, valueWork);
+			}
+
+			objControl.value = String(valueWork);
+			break;
+		}
+
+		case "select": {
+
+			// 現在の選択肢に存在しない値は復元しない（初期選択のまま）
+			const valueText = String(value);
+			for (const objOption of objControl.options) {
+				if (objOption.value === valueText) {
+					objControl.value = valueText;
+					break;
+				}
+			}
+			break;
+		}
+		}
+	}
+
+	/**
+	 * 画面部品へ変更時の保存処理をバインドする.
+	 * （再計算用のイベントリスナーとは独立に動作する）
+	 */
+	static BindPersistence () {
+
+		for (const fieldDef of this.fieldDefs) {
+
+			const objControl = document.getElementById(fieldDef.objId);
+			if (!objControl) {
+				continue;
+			}
+
+			objControl.addEventListener("change", () => {
+				CReceivedDamageConfManager.SaveFromControls();
+			});
+		}
+	}
+
+	/**
+	 * 画面部品の現在値をローカルストレージへ保存する.
+	 * （画面に存在しない項目・空欄の項目は、保存済みの値を維持する）
+	 */
+	static SaveFromControls () {
+
+		const conf = this.#loadConf();
+		conf.version = this.VERSION;
+
+		for (const fieldDef of this.fieldDefs) {
+
+			const objControl = document.getElementById(fieldDef.objId);
+			if (!objControl) {
+				continue;
+			}
+
+			if (fieldDef.type === "number") {
+
+				// 空欄や数値でない入力は保存しない（Number("") === 0 となるため空欄は明示的に除外）
+				if (objControl.value.trim() === "") {
+					continue;
+				}
+				const valueWork = Number(objControl.value);
+				if (!Number.isFinite(valueWork)) {
+					continue;
+				}
+				conf[fieldDef.key] = valueWork;
+			}
+			else {
+				conf[fieldDef.key] = objControl.value;
+			}
+		}
+
+		try {
+			localStorage.setItem(this.STORAGE_NAME, JSON.stringify(conf));
+		}
+		catch (e) {
+			// ローカルストレージが使用不可の場合は保存しない
+		}
+	}
+}

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -5,6 +5,7 @@ import '../../../roro/m/js/data/mig.itemsp.h.js';
 import { CBattleCalcInfo } from './CBattleCalcInfo.js';
 import { CBattleCalcResult } from './CBattleCalcResult.js';
 import { CBattleCalcResultAll } from './CBattleCalcResultAll.js';
+import { CReceivedDamageConfManager } from './CReceivedDamageConfManager.js';
 import { AS_Calc, AS_PLUS, AUTO_SPELL_SETTING_COUNT, OBJID_OFFSET_AS_SKILL_ID, n_AS_SKILL } from './calcautospell.js';
 import {
          GetHigherJobSeriesID, GetJobLevelMax, GetLowerJobSeriesID, IsDoramJob,
@@ -11506,14 +11507,16 @@ export function BuildBattleResultHtmlMIG(charaData, specData, mobData, attackMet
 	}
 	objCell.classList.add("BTLRSLT_TAB_RESULT");
 	objCell.classList.add("CSSCLS_BTLRSLT_HEADER");
-	funcAppendCheckbox(objCell, partIdStr, "平均被ダメージ（仮）", uncheckedMap.get(partIdStr), funcOnChangeChkPart);
+	objCell.classList.add("CSSCLS_BTLRSLT_RECEIVE_HEADER");
+	funcAppendCheckbox(objCell, partIdStr, "最大被ダメージ", uncheckedMap.get(partIdStr), funcOnChangeChkPart);
 	{
-		const objLabel = objCell.querySelector(`label[for="${partIdStr}"]`);
-		HtmlRemoveAllChild(objLabel);
-		const objLink = HtmlCreateElement("a", objLabel);
+		// 敵スキルの倍率・属性の参考情報へのリンク（タイトルのトグル操作と分離して右寄せ表示する）
+		const objLink = HtmlCreateElement("a", objCell);
 		objLink.setAttribute("href", "https://github.com/roratorio-hub/ratorio/wiki/received_damage");
 		objLink.setAttribute("target", "_blank");
-		HtmlCreateTextNode("平均被ダメージ（仮）", objLink);
+		objLink.setAttribute("title", "被ダメージ計算の使い方と、敵スキルの倍率・属性の参考情報（GitHub wiki）");
+		objLink.classList.add("CSSCLS_BTLRSLT_RECEIVE_HELP_LINK");
+		HtmlCreateTextNode("📖 敵スキルの倍率・属性を調べる", objLink);
 	}
 
 	//----------------
@@ -11551,17 +11554,6 @@ export function BuildBattleResultHtmlMIG(charaData, specData, mobData, attackMet
 	objPhysicalDamageView.classList.add("BTLRSLT_TAB_RESULT");
 	objPhysicalDamageView.classList.add(partIdStr);
 	objPhysicalDamageView.classList.add("CSSCLS_BTLRSLT_VALUE");
-	if (n_B_KYOUKA[MOB_CONF_BUF_ID_MAX_PAIN] == 0) {
-		calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
-		enemy_skill_ratio.addEventListener("change", () => {
-			calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
-		});
-		enemy_skill_element.addEventListener("change", () => {
-			calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
-		});
-	} else {
-		BattleHiDamMaxPain(charaData, specData, mobData, attackMethodConfArray, battleCalcResultAll.GetDamageSummaryAvePerAtk(), objPhysicalDamageView);
-	}
 
 	//----------------
 	// 魔法ダメージ
@@ -11597,6 +11589,27 @@ export function BuildBattleResultHtmlMIG(charaData, specData, mobData, attackMet
 	objMagicalDamageView.classList.add("BTLRSLT_TAB_RESULT");
 	objMagicalDamageView.classList.add(partIdStr);
 	objMagicalDamageView.classList.add("CSSCLS_BTLRSLT_VALUE");
+
+	//----------------
+	// 設定の復元と初期計算
+	//----------------
+
+	// 保存済みの被ダメージ計算設定を復元する（初回計算より前に行うこと）
+	CReceivedDamageConfManager.RestoreToControls();
+	CReceivedDamageConfManager.BindPersistence();
+
+	if (n_B_KYOUKA[MOB_CONF_BUF_ID_MAX_PAIN] == 0) {
+		calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
+		enemy_skill_ratio.addEventListener("change", () => {
+			calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
+		});
+		enemy_skill_element.addEventListener("change", () => {
+			calcReceivedDamage(charaData, specData, mobData, attackMethodConfArray, objPhysicalDamageView);
+		});
+	} else {
+		BattleHiDamMaxPain(charaData, specData, mobData, attackMethodConfArray, battleCalcResultAll.GetDamageSummaryAvePerAtk(), objPhysicalDamageView);
+	}
+
 	calcReceivedMagicDamage(charaData, mobData, objMagicalDamageView);
 	enemy_magic_skill_ratio.addEventListener("change", () => {
 		calcReceivedMagicDamage(charaData, mobData, objMagicalDamageView);
@@ -11919,9 +11932,11 @@ export function calcReceivedDamage(charaData, specData, mobData, attackMethodCon
 		w_HiDam[6] = Math.floor(w_HiDam[6]);
 	}
 
-	wBHD=0;
-	for(i = 0; i <= 6; i++) wBHD += w_HiDam[i];
-	wBHD = Math.round(wBHD / 7);
+	// wBHD=0;
+	// for(i = 0; i <= 6; i++) wBHD += w_HiDam[i];
+	// wBHD = Math.round(wBHD / 7);
+	// 壁目線では最大被ダメが知りたいはずなので平均は取らない
+	wBHD = w_HiDam[6];
 
 	/** 反射ダメージの計算 */
 	{
@@ -12032,9 +12047,11 @@ export function calcReceivedDamage(charaData, specData, mobData, attackMethodCon
  * @param {*} objCell 
  */
 export function calcReceivedMagicDamage(charaData, mobData, objCell){
-	let mobMinMATK = mobData[MONSTER_DATA_EXTRA_INDEX_MATK_MIN];
+	// let mobMinMATK = mobData[MONSTER_DATA_EXTRA_INDEX_MATK_MIN];
 	let mobMaxMATK = mobData[MONSTER_DATA_EXTRA_INDEX_MATK_MAX];
-	let damage = (mobMinMATK + mobMaxMATK) / 2;
+	//	let damage = (mobMinMATK + mobMaxMATK) / 2;
+	// 壁目線では最大被ダメを知りたいはずなので平均は取らない
+	let damage = mobMaxMATK;
 	let ratio = 0;
 
 	const enemy_magic_skill_ratio_elm = document.getElementById("OBJID_ENEMY_MAGIC_SKILL_RATIO");

--- a/roro/m/calcx.css
+++ b/roro/m/calcx.css
@@ -433,6 +433,18 @@ td.CSSCLS_EXTRA_INFO_DISP_TABLE_SKILL_CARD_NG {
 	background-color : #ddddff;
 }
 
+/* 被ダメージヘッダー（タイトル左寄せ・参考情報リンク右寄せ） */
+.CSSCLS_BTLRSLT_RECEIVE_HEADER {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+}
+.CSSCLS_BTLRSLT_RECEIVE_HELP_LINK {
+	margin-left: auto;
+	font-size: small;
+	white-space: nowrap;
+}
+
 .CSSCLS_BTLRSLT_METHOD_LABEL, .CSSCLS_BTLRSLT_RAYING_LABEL {
 	background-color : #ddeedd;
 }

--- a/tests/ro4/CReceivedDamageConfManager.test.ts
+++ b/tests/ro4/CReceivedDamageConfManager.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CReceivedDamageConfManager } from '@ro4/CReceivedDamageConfManager.js';
+
+const STORAGE_NAME = CReceivedDamageConfManager.STORAGE_NAME;
+
+// head.js の被ダメージ計算設定欄と同じ構成の画面部品を生成する
+function buildControls() {
+    const mkRatio = (id: string) => {
+        const input = document.createElement('input');
+        input.id = id;
+        input.setAttribute('type', 'number');
+        input.setAttribute('min', '100');
+        input.setAttribute('max', '60000');
+        input.value = '100';
+        document.body.appendChild(input);
+        return input;
+    };
+    const mkElement = (id: string, values: number[]) => {
+        const sel = document.createElement('select');
+        sel.id = id;
+        for (const v of values) {
+            const opt = document.createElement('option');
+            opt.value = String(v);
+            sel.appendChild(opt);
+        }
+        document.body.appendChild(sel);
+        return sel;
+    };
+    return {
+        physRatio: mkRatio('OBJID_ENEMY_SKILL_RATIO'),
+        physElem: mkElement('OBJID_ENEMY_SKILL_ELEMENT', [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        magRatio: mkRatio('OBJID_ENEMY_MAGIC_SKILL_RATIO'),
+        magElem: mkElement('OBJID_ENEMY_MAGIC_SKILL_ELEMENT', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    };
+}
+
+describe('CReceivedDamageConfManager', () => {
+
+    beforeEach(() => {
+        localStorage.clear();
+        document.body.innerHTML = '';
+    });
+
+    it('保存した値を再構築後の画面部品へ復元する（ラウンドトリップ）', () => {
+        let c = buildControls();
+        c.physRatio.value = '1500';
+        c.physElem.value = '3';
+        c.magRatio.value = '250';
+        c.magElem.value = '7';
+        CReceivedDamageConfManager.SaveFromControls();
+
+        // DOM再構築（初期値に戻る）を再現
+        document.body.innerHTML = '';
+        c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+
+        expect(c.physRatio.value).toBe('1500');
+        expect(c.physElem.value).toBe('3');
+        expect(c.magRatio.value).toBe('250');
+        expect(c.magElem.value).toBe('7');
+    });
+
+    it('保存データがない場合は画面部品の初期値を変更しない', () => {
+        const c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+        expect(c.physRatio.value).toBe('100');
+        expect(c.physElem.value).toBe('-1');
+        expect(c.magElem.value).toBe('0');
+    });
+
+    it('壊れたJSONが保存されていても例外にならず初期値のまま', () => {
+        localStorage.setItem(STORAGE_NAME, '{broken json!!');
+        const c = buildControls();
+        expect(() => CReceivedDamageConfManager.RestoreToControls()).not.toThrow();
+        expect(c.physRatio.value).toBe('100');
+    });
+
+    it('バージョンが一致しない保存データは無視する', () => {
+        localStorage.setItem(STORAGE_NAME, JSON.stringify({ version: 999, physicalRatio: 5000 }));
+        const c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+        expect(c.physRatio.value).toBe('100');
+    });
+
+    it('範囲外の倍率は min / max 属性の範囲へクランプして復元する', () => {
+        localStorage.setItem(STORAGE_NAME, JSON.stringify({
+            version: CReceivedDamageConfManager.VERSION,
+            physicalRatio: 999999,
+            magicalRatio: 1,
+        }));
+        const c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+        expect(c.physRatio.value).toBe('60000');
+        expect(c.magRatio.value).toBe('100');
+    });
+
+    it('選択肢に存在しない属性値は復元せず初期選択のまま', () => {
+        localStorage.setItem(STORAGE_NAME, JSON.stringify({
+            version: CReceivedDamageConfManager.VERSION,
+            physicalElement: '42',
+            magicalElement: '5',
+        }));
+        const c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+        expect(c.physElem.value).toBe('-1');    // 不正値 → 初期選択のまま
+        expect(c.magElem.value).toBe('5');      // 正常値 → 復元される
+    });
+
+    it('BindPersistence 後は change イベントで localStorage へ保存される', () => {
+        const c = buildControls();
+        CReceivedDamageConfManager.RestoreToControls();
+        CReceivedDamageConfManager.BindPersistence();
+
+        c.physRatio.value = '3000';
+        c.physRatio.dispatchEvent(new Event('change'));
+
+        const saved = JSON.parse(localStorage.getItem(STORAGE_NAME)!);
+        expect(saved.physicalRatio).toBe(3000);
+    });
+
+    it('画面に存在しない項目の保存値は上書きされず維持される', () => {
+        let c = buildControls();
+        c.magElem.value = '8';
+        CReceivedDamageConfManager.SaveFromControls();
+
+        // 魔法属性の select が存在しない画面で保存しても、保存済みの値は残る
+        document.body.innerHTML = '';
+        c = buildControls();
+        c.magElem.remove();
+        c.physRatio.value = '2000';
+        CReceivedDamageConfManager.SaveFromControls();
+
+        const saved = JSON.parse(localStorage.getItem(STORAGE_NAME)!);
+        expect(saved.physicalRatio).toBe(2000);
+        expect(saved.magicalElement).toBe('8');
+    });
+
+    it('空欄の倍率は保存せず、保存済みの値を維持する', () => {
+        const c = buildControls();
+        c.physRatio.value = '1200';
+        CReceivedDamageConfManager.SaveFromControls();
+
+        c.physRatio.value = '';
+        CReceivedDamageConfManager.SaveFromControls();
+
+        const saved = JSON.parse(localStorage.getItem(STORAGE_NAME)!);
+        expect(saved.physicalRatio).toBe(1200);
+    });
+});


### PR DESCRIPTION
装備やバフを変更するたびに戦闘結果エリアが再構築され、 被ダメージ計算の倍率・属性設定が初期値に戻る問題を改善する。

- 被ダメージ計算設定（物理/魔法の倍率・属性）をローカルストレージへ 保存し、DOM再構築時に復元する CReceivedDamageConfManager を新設
  - 保存キー RRTRDC（JSON形式・バージョン付き）
  - 既定値と値域は DOM 構築側（head.js）を唯一の情報源とし、 不正な保存値は画面の初期値へ縮退する
  - 今後の設定項目追加は fieldDefs への1行追加で対応可能
- ヘッダーの wiki リンクをセクションタイトルから分離し、 「📖 敵スキルの倍率・属性を調べる」として右寄せ表示 （折りたたみトグルとリンクの誤操作を解消し、リンク先の内容を明示）
- 被ダメージ表示を平均値から最大値へ変更し、ラベルを「最大被ダメージ」に （壁運用の目線では最大被ダメージを知りたいため）