### PR TITLE
fix(dewindow): 未宣言変数の読み取りによる ReferenceError 6件を修正

### DIFF
--- a/ro4/m/js/CShadowEquipController.js
+++ b/ro4/m/js/CShadowEquipController.js
@@ -115,12 +115,12 @@ export class CShadowEquipController {
 
 	/**
 	 * 有効な装備箇所名の配列を取得する.
-	 * @param {boolean} bDualArms 二刀流フラグ
+	 * @param {boolean} bDualShadowArms 二刀流フラグ
 	 */
 	static getEqprgnNames (bDualShadowArms) {
 
 		// シャドウ装備二刀流の場合
-		if (bDualArms) {
+		if (bDualShadowArms) {
 			// TODO: 現状、そのような仕様はないので、未対応
 			return [
 				this.EQPRGN_NAME_ARMS_RIGHT,

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -587,7 +587,8 @@ import {
 
 // C-6: 共有 state（旧 foot.js window 変数）
 import {
-         SU_STR, n_A_JobLV, n_A_STR, n_A_AGI,
+         SU_STR, SU_AGI, SU_VIT, SU_INT, SU_DEX, SU_LUK,
+         n_A_JobLV, n_A_STR, n_A_AGI,
          n_A_VIT, n_A_DEX, n_A_INT, n_A_LUK,
          n_A_WeaponType, n_A_HEAD_DEF_PLUS, n_A_BODY_DEF_PLUS, n_A_SHIELD_DEF_PLUS,
          n_A_SHOULDER_DEF_PLUS, n_A_SHOES_DEF_PLUS, n_A_WeaponLV, n_A_Weapon_ATK,
@@ -6226,7 +6227,11 @@ export function BattleCalc999Core(battleCalcInfo, charaData, specData, mobData, 
 			n_Delay[7] = 0;
 
 			// 威力に影響するＤＥＦは５００まで
-			var defpower =  B_Original_DEF > 500 ? 500 :  B_Original_DEF;
+			// dewindow: 旧 mob.js の暗黙グローバル B_Original_DEF（除算DEF補正前の値）を参照していたが、
+			// 移行時に mob.js 側が関数ローカル var 化され ReferenceError になっていた。
+			// 同値が mobData[MONSTER_DATA_INDEX_DEF_DIV_IGNORE_BUFF]（補正前の値を保持）に入っているためそれを使う。
+			var origDef = mobData[MONSTER_DATA_INDEX_DEF_DIV_IGNORE_BUFF];
+			var defpower =  origDef > 500 ? 500 :  origDef;
 			wbairitu = (200 + defpower) * n_A_ActiveSkillLV;
 
 			var AS_ATK = 0;

--- a/roro/m/js/CSkillManager.js
+++ b/roro/m/js/CSkillManager.js
@@ -23387,7 +23387,7 @@ export function CSkillManager() {
 				pow = 60 * skillLv;
 				powCart = 50 * Math.max(LearnedSkillSearch(SKILL_ID_CART_KAIZO), UsedSkillSearch(SKILL_ID_CART_KAIZO));
 				powInt = charaDataManger.GetCharaInt() / 40;
-				pow += Math.floor(powCard * powInt);
+				pow += Math.floor(powCart * powInt);
 
 				return pow;
 			}

--- a/roro/m/js/hmrndopt.js
+++ b/roro/m/js/hmrndopt.js
@@ -743,10 +743,10 @@ export function GetRndOptValue(eqpRgnId, spid, invalidItemIdArray, bListUp) {
 			spValPureStatus = Math.floor(pureParamArray[spDefPureStatusBy - 1] / 10);
 		}
 		else if (7 == spDefPureStatusBy) {
-			spValPureStatus = pureStatusValue[PARAM_DEX];
+			spValPureStatus = pureParamArray[PARAM_DEX];
 		}
 		else if (8 == spDefPureStatusBy) {
-			spValPureStatus = pureStatusValue[PARAM_VIT];
+			spValPureStatus = pureParamArray[PARAM_VIT];
 		}
 		spDefRemain = spDefRemain % ITEM_SP_PURE_STR_BY_10_OFFSET;
 

--- a/roro/m/js/saveload.js
+++ b/roro/m/js/saveload.js
@@ -5289,104 +5289,11 @@ export function SaveCookieConf(){
 	// アクティブスキルの限界攻撃間隔を取得し、クッキー文字列に変換
 	wStr += NtoS2(eval(document.calcForm.Conf01.value), 2);
 
-	if(n_CONFIG_SW){
-
-		// セーブデータの保存数を取得
-		// 基本＝１～１９番、拡張＝２０～５００番、全体＝１～５００番
-		var wMAX = eval(document.calcForm.Conf02.value);
-
-		// 保持しているセーブデータの保存数１９番までで、新たに入力された保存数が１９より大きい場合
-		// すなわち、拡張セーブデータが有効にされた場合
-		if(n_CONFIG[2] == 19 && wMAX > 19){
-
-			// 全体セーブデータが存在する場合
-			if(localStorage.ROratorioDOM_SaveData){
-
-				// 全体セーブデータの読み込み
-				var wSave = new Array();
-				var wYYY = localStorage.ROratorioDOM_SaveData;
-				wSave = wYYY.split("?");
-
-				// 拡張セーブデータに、読み込んだデータを設定
-				for(var i = 20; i <= 500; i++) {
-					SaveDataAll[i] = wSave[i];
-				}
-
-				// 基本セーブデータの存在検査
-				var ch = 0;
-				for(var i = 1; i <= 19; i++){
-					if(SaveDataAll[i] != "ZZZZ") ch = 1;
-				}
-
-				// 基本セーブデータが１件も無い場合
-				if(ch == 0){
-
-					// 基本セーブデータに、読み込んだデータを設定
-					for(var i = 1; i <= 19; i++) {
-						SaveDataAll[i] = wSave[i];
-					}
-
-					// 基本セーブデータ文字列をを生成
-					var wStrX = "" + SaveDataAll[0];
-					for(var i = 1; i <= 19; i++) {
-						wStrX += "?" + SaveDataAll[i];
-					}
-
-					// 有効期限を設定して、クッキーに基本セーブデータを保存
-					expireDateString = GetExpireDateString();
-					document.cookie = "ROratorioSave" +"="+ wStrX +";expires="+ expireDateString;
-				}
-			}
-
-			// 全体セーブデータが存在しない場合
-			else{
-				// 拡張セーブデータに、データなしを設定
-				for(var i = 20; i <= 500; i++) {
-					SaveDataAll[i] = "ZZZZ";
-				}
-			}
-
-			// 全体セーブデータ文字列を生成し、保存
-			var wXXX = "" + SaveDataAll[0];
-			for(var i = 1; i <= 500; i++) {
-				wXXX += "?" + SaveDataAll[i];
-			}
-			localStorage.ROratorioDOM_SaveData = wXXX;
-
-			// 名前の保存
-			if(localStorage.ROratorioDOM_SaveName){
-				var wStrX = localStorage.ROratorioDOM_SaveName;
-				set_SaveNameAll(wStrX.split("|"));
-			}
-
-			myInnerHtml("DELHTML",'　　<input type="text" name="SAVE_NAME" value="名前入力可能" size=30>　　<Font size=2><A Href="del2.html">セーブ削除</A></Font>',0);
-			kirikae=1;
-		}
-
-		// 保持しているセーブデータの保存数が、新たに入力された保存数より大きい場合
-		else if(n_CONFIG[2] < wMAX){
-			kirikae=1;
-		}
-
-		// 保持しているセーブデータの保存数より、新たに入力された保存数が小さい場合
-		else if(n_CONFIG[2] > wMAX){
-
-			// セーブスロットの選択肢を減らす
-			for(var i = n_CONFIG[2]; i != wMAX; i--) {
-				document.calcForm.A_SaveSlot.options[i-1] = null;
-			}
-
-			kirikae=1;
-
-			// １９番までしか使用できない場合は、名前入力を可能としない
-			if(wMAX == 19) {
-				myInnerHtml("DELHTML",'　　<Font size=2><A Href="del.html">セーブ削除</A></Font>',0);
-			}
-		}
-
-		// セーブデータの保存数を保持しておく
-		n_CONFIG[2] = eval(document.calcForm.Conf02.value);
-	}
+	// dewindow: ここにあった `if(n_CONFIG_SW){ ... }`（98行・拡張セーブデータ 20〜500番への移行処理）を除去した。
+	// n_CONFIG_SW は初期コミットから一度も定義されておらず、この行は常に ReferenceError を投げていたため、
+	// ブロックは一度も実行されていない。throw によって以降の cookie 保存（下記）まで到達できず、
+	// 旧 ConfData クッキー保持者の LoadSaveDataToCalculator() が中断していた。
+	// 「一度も実行されていない」実挙動を保存したまま throw のみを解消する。
 
 	// セーブデータの保存数を、クッキー文字列に変換＆追記
 	wStr += NtoS2(n_CONFIG[2],2);

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,9 @@
         "test:ui": "vitest --ui",
         "test:integration": "vitest run --config vitest.integration.config.ts",
         "test:staging-diff": "vitest run --config vitest.staging.config.ts",
-        "scan:undeclared": "node scan-undeclared-writes.mjs"
+        "scan:undeclared": "node scan-undeclared-writes.mjs && node scan-undeclared-reads.mjs",
+        "scan:undeclared-writes": "node scan-undeclared-writes.mjs",
+        "scan:undeclared-reads": "node scan-undeclared-reads.mjs"
     },
     "engines": {
         "node": ">=20.0.0",

--- a/tests/ro4/CShadowEquipController.test.ts
+++ b/tests/ro4/CShadowEquipController.test.ts
@@ -33,4 +33,22 @@ describe('CShadowEquipController.js', () => {
             expect(bridge.isShadowEquipAvailable()).toBe(true);
         });
     });
+
+    // 仮引数は bDualShadowArms なのに本体が bDualArms を読んでおり、
+    // 呼び出すと必ず ReferenceError になっていた（現状は呼び出し元が無く潜伏）。
+    describe('getEqprgnNames', () => {
+        const EXPECTED = [
+            'eqprgn-arms-right', 'eqprgn-arms-left', 'eqprgn-body',
+            'eqprgn-foot', 'eqprgn-accessory-1', 'eqprgn-accessory-2',
+        ];
+
+        it('二刀流フラグ false で装備箇所名を返す', () => {
+            expect(CShadowEquipController.getEqprgnNames(false)).toEqual(EXPECTED);
+        });
+
+        // 二刀流は「現状そのような仕様はない」ため、今は同じ配列を返すのが正
+        it('二刀流フラグ true でも同じ装備箇所名を返す', () => {
+            expect(CShadowEquipController.getEqprgnNames(true)).toEqual(EXPECTED);
+        });
+    });
 });

--- a/tests/roro/CSkillManager.cartcannon.test.ts
+++ b/tests/roro/CSkillManager.cartcannon.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * カートキャノンの Power 計算の回帰テスト。
+ *
+ * バグ: `var powCart` を宣言・代入しておきながら、続く式が `powCard` を読んでいた（タイポ）。
+ * ESM は常に strict mode なので bare な未定義識別子の読み取りは ReferenceError になる。
+ * カートキャノンを選択したときだけ通る分岐なので integration 全緑のまま潜伏していた。
+ *
+ * TDZ 回避の import 順は CSkillManager.test.ts と同じ理由（reference.md「global.js の module-level Init」）。
+ */
+let sm: any;
+let SKILL_ID_CART_CANNON: number;
+let SKILL_ID_CART_KAIZO: number;
+
+/** LearnedSkillSearch / UsedSkillSearch は注入パターン。テスト用に固定値を返す実体を差し込む。 */
+let learnedLv = 0;
+let usedLv = 0;
+
+beforeAll(async () => {
+    await import('@roro/CGlobalConstManager.js');
+    const skillDat = await import('@roro/skill.dat.js');
+    SKILL_ID_CART_CANNON = skillDat.SKILL_ID_CART_CANNON;
+    SKILL_ID_CART_KAIZO = skillDat.SKILL_ID_CART_KAIZO;
+    await import('@ro4/global.js');
+    const mod = await import('@roro/CSkillManager.js');
+    mod.RegisterLearnedSkillSearch((id: number) => (id === SKILL_ID_CART_KAIZO ? learnedLv : 0));
+    mod.RegisterUsedSkillSearch((id: number) => (id === SKILL_ID_CART_KAIZO ? usedLv : 0));
+    sm = new mod.CSkillManager();
+});
+
+/** charaDataManger のうち Power が使うのは GetCharaInt のみ。 */
+const chara = (int: number) => ({ GetCharaInt: () => int });
+
+describe('CSkillManager: カートキャノンの威力計算', () => {
+    it('カート改造Lv と INT に応じた加算を行う（60*Lv + floor(50*カート改造Lv * INT/40)）', () => {
+        learnedLv = 10;
+        usedLv = 0;
+        // 60*5 + floor(50*10 * 80/40) = 300 + floor(500*2) = 1300
+        expect(sm.GetPower(SKILL_ID_CART_CANNON, 5, chara(80))).toBe(1300);
+    });
+
+    it('カート改造が未修得なら基本式のみ（60*Lv）', () => {
+        learnedLv = 0;
+        usedLv = 0;
+        expect(sm.GetPower(SKILL_ID_CART_CANNON, 5, chara(80))).toBe(300);
+    });
+
+    it('修得Lvと使用Lvのうち大きい方を採用する', () => {
+        learnedLv = 3;
+        usedLv = 10;
+        // max(3,10)=10 → 300 + floor(500 * 1) = 800
+        expect(sm.GetPower(SKILL_ID_CART_CANNON, 5, chara(40))).toBe(800);
+    });
+
+    it('INT が 40 未満でも小数を切り捨てて加算する', () => {
+        learnedLv = 1;
+        usedLv = 0;
+        // 60*1 + floor(50*1 * 10/40) = 60 + floor(12.5) = 72
+        expect(sm.GetPower(SKILL_ID_CART_CANNON, 1, chara(10))).toBe(72);
+    });
+});

--- a/tests/scan-undeclared-reads.mjs
+++ b/tests/scan-undeclared-reads.mjs
@@ -1,0 +1,215 @@
+/**
+ * 未宣言変数の「読み取り」検出スキャナ（scan-undeclared-writes.mjs の対になるもの）
+ *
+ * 姉妹スキャナが write のみを見て read を明示的に無視しているため、
+ * 「宣言も import もされていない変数を読む」バグは検出できない状態だった。
+ * ESM は常に strict mode なので、未定義識別子の読み取りは実行時 ReferenceError になる。
+ * これは「その分岐を通る操作をしたときだけ」落ちるため、integration 全緑のまますり抜ける。
+ * （実例: head.js の SU_INT 等20箇所 / CSkillManager の powCard タイポ / saveload の n_CONFIG_SW）
+ *
+ * bare read の大半は CGlobalConstManager.DefineEnum() が実行時に生成する定数なので、
+ * その名前を全て収集して除外した上で、残ったものだけを報告する。
+ *
+ * 実行: cd tests && node scan-undeclared-reads.mjs
+ * 終了コード: 検出 0 件で 0、検出ありで 1（CI gate に利用可）
+ */
+import { Linter } from 'eslint';
+import { readdirSync, statSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(process.cwd(), '..');
+const SCAN_DIRS = ['roro/m/js', 'ro4/m/js', 'roro/other/js', 'roro/common/js'];
+const EXTRA_FILES = ['ro4/m/calcx-ai.js'];
+
+// classic script（type="module" でない <script>）が定義する真のグローバルを収集する対象
+const CLASSIC_DIRS = ['lib', 'jquery'];
+// TypeScript 層（workspace/）が window に生やすシンボルを収集する対象
+const TS_DIR = 'workspace/src';
+
+// ブラウザ / JS 組み込み。ESLint の globals パッケージが無いため明示列挙する。
+const BUILTINS = new Set([
+    'undefined', 'NaN', 'Infinity', 'globalThis', 'console', 'Math', 'JSON', 'Object', 'Array',
+    'String', 'Number', 'Boolean', 'Date', 'RegExp', 'Error', 'TypeError', 'RangeError', 'Map',
+    'Set', 'WeakMap', 'WeakSet', 'Promise', 'Symbol', 'Proxy', 'Reflect', 'BigInt', 'parseInt',
+    'parseFloat', 'isNaN', 'isFinite', 'encodeURIComponent', 'decodeURIComponent', 'encodeURI',
+    'decodeURI', 'escape', 'unescape', 'eval', 'Function', 'setTimeout', 'setInterval',
+    'clearTimeout', 'clearInterval', 'queueMicrotask', 'requestAnimationFrame',
+    'cancelAnimationFrame', 'structuredClone', 'btoa', 'atob',
+    'window', 'document', 'navigator', 'location', 'history', 'screen', 'self', 'top', 'parent',
+    'opener', 'frames', 'localStorage', 'sessionStorage', 'performance', 'crypto',
+    'alert', 'confirm', 'prompt', 'open', 'close', 'print', 'focus', 'blur', 'scrollTo',
+    'getComputedStyle', 'matchMedia',
+    'fetch', 'XMLHttpRequest', 'FormData', 'Blob', 'File', 'FileReader', 'URL', 'URLSearchParams',
+    'Headers', 'Response', 'Request', 'AbortController', 'AbortSignal', 'WebSocket', 'Worker',
+    'MessageChannel', 'Notification', 'Intl',
+    'Uint8Array', 'Int8Array', 'Uint16Array', 'Int16Array', 'Uint32Array', 'Int32Array',
+    'Float32Array', 'Float64Array', 'ArrayBuffer', 'DataView', 'TextEncoder', 'TextDecoder',
+    'Image', 'Option', 'Audio', 'Range', 'Selection', 'DOMParser',
+    'Event', 'CustomEvent', 'MouseEvent', 'KeyboardEvent', 'Node', 'Element', 'HTMLElement',
+    'HTMLCollection', 'NodeList', 'Text', 'DocumentFragment', 'CSSStyleDeclaration', 'Storage',
+    'FileList', 'Window', 'SVGElement', 'HTMLInputElement', 'HTMLSelectElement',
+    'HTMLCanvasElement', 'HTMLImageElement', 'HTMLFormElement', 'HTMLTableElement',
+    'HTMLOptGroupElement', 'HTMLOptionElement', 'HTMLTableRowElement', 'HTMLTableCellElement',
+    'MutationObserver', 'IntersectionObserver', 'ResizeObserver',
+    // 外部ライブラリ（CDN / lib 配下の classic script）
+    '$', 'jQuery', 'TomSelect', 'Chart', 'html2canvas',
+]);
+
+// 静的には追えないが、デッドコード内のためランタイムに到達しないことを確認済みの名前。
+// ここに足すのは「呼び出し元が存在しない関数の中」に限ること。到達しうるなら必ず直す。
+const DEAD_CODE_ALLOWLIST = new Map([
+    ['n_EnchantType', 'hmcard.js BuildUpCardSlotsCard/Enchant は呼び出し元なし（デッド）'],
+    ['n_EnchantList', 'hmcard.js BuildUpCardSlotsCard/Enchant は呼び出し元なし（デッド）'],
+    ['n_A_PassSkill8', 'mig.job.h.js UpgradeJobTo4th は呼び出し元なし（デッド）。import すると skillstate→item.h→mig.job.h の循環になるため据置'],
+    ['Click_CONFIG', 'foot.js で try/catch に包まれた「次世代版では消える」暫定呼び出し'],
+]);
+// mig.itemsp.h.js は export 15個中14個が未呼び出しのデッドファイル。
+// MIG_STATE_ID_* / MIG_JOB_SERIES_ID_* 等が未定義のまま残っているが到達しない。
+// ファイルごと削除するのが本筋（要承認）。それまではファイル単位で除外する。
+const DEAD_FILE_ALLOWLIST = new Set(['roro/m/js/data/mig.itemsp.h.js']);
+
+// ── 対象ファイル収集 ──
+function walk(dir, acc) {
+    if (!existsSync(dir)) return acc;
+    for (const e of readdirSync(dir)) {
+        const p = join(dir, e);
+        if (statSync(p).isDirectory()) walk(p, acc);
+        else if (e.endsWith('.js')) acc.push(p);
+    }
+    return acc;
+}
+let files = [];
+for (const d of SCAN_DIRS) walk(join(ROOT, d), files);
+for (const f of EXTRA_FILES) {
+    const p = join(ROOT, f);
+    if (existsSync(p)) files.push(p);
+}
+
+// ── DefineEnum が実行時生成する定数名の収集 ──
+// CGlobalConstManager.DefineEnumSubCommon が Function(name + " = " + value + ";")() で
+// グローバルへ直接生やすため、静的には一切追えない。名前を集めて除外する。
+function collectEnumNames(srcFiles) {
+    const names = new Set();
+    const reCall = /CGlobalConstManager\.(?:DefineEnum|DefinePseudoEnum)\s*\(/g;
+    const reIdentStr = /["']([A-Za-z_$][\w$]*)["']/g;
+    for (const f of srcFiles) {
+        const src = readFileSync(f, 'utf8');
+        // 1) DefineEnum(...) の実引数に現れる識別子形の文字列リテラル
+        let m, mm;
+        while ((m = reCall.exec(src))) {
+            let i = src.indexOf('(', m.index);
+            let depth = 0, j = i;
+            for (; j < src.length; j++) {
+                if (src[j] === '(') depth++;
+                else if (src[j] === ')' && --depth === 0) break;
+            }
+            const arg = src.slice(i, j + 1)
+                .replace(/\/\*[\s\S]*?\*\//g, '')
+                .replace(/\/\/[^\n]*/g, '');
+
+            while ((mm = reIdentStr.exec(arg))) names.add(mm[1]);
+        }
+        // 2) SetEnumName("X") / enumName = "X" 経由（CConfBase 系の登録パターン）
+        for (const re of [/SetEnumName\s*\(\s*["']([A-Za-z_$][\w$]*)["']/g,
+                          /\benumName\s*=\s*["']([A-Za-z_$][\w$]*)["']/g]) {
+            while ((mm = re.exec(src))) names.add(mm[1]);
+        }
+    }
+    return names;
+}
+
+// ── classic script / TypeScript 層が生やすグローバルの収集 ──
+function collectHostGlobals() {
+    const names = new Set();
+    let classicFiles = [];
+    for (const d of CLASSIC_DIRS) walk(join(ROOT, d), classicFiles);
+    // minified バンドルは誤検出のもとなので除外
+    classicFiles = classicFiles.filter((f) => !/\.min\.js$/.test(f));
+    for (const f of classicFiles) {
+        const src = readFileSync(f, 'utf8');
+        let m;
+        const re = /^\s*(?:function\s+([A-Za-z_$][\w$]*)|var\s+([A-Za-z_$][\w$]*)\s*=)/gm;
+        while ((m = re.exec(src))) names.add(m[1] || m[2]);
+    }
+    // workspace TS が window に生やすシンボル（Layer1 から bare 参照される）
+    const tsDir = join(ROOT, TS_DIR);
+    if (existsSync(tsDir)) {
+        let tsFiles = [];
+        (function w(d) {
+            for (const e of readdirSync(d)) {
+                const p = join(d, e);
+                if (statSync(p).isDirectory()) w(p);
+                else if (e.endsWith('.ts')) tsFiles.push(p);
+            }
+        })(tsDir);
+        const re = /\(\s*window\s+as\s+any\s*\)\.([A-Za-z_$][\w$]*)\s*=|declare\s+function\s+([A-Za-z_$][\w$]*)/g;
+        for (const f of tsFiles) {
+            let m;
+            const src = readFileSync(f, 'utf8');
+            while ((m = re.exec(src))) names.add(m[1] || m[2]);
+        }
+    }
+    return names;
+}
+
+const enumNames = collectEnumNames(files);
+const hostGlobals = collectHostGlobals();
+
+// engine-registry / bridge 経由で登録される Workspace I/F（window 残置の2件を含む）
+const REGISTRY_IF = new Set(['StAllCalc', 'AutoCalc']);
+
+// ── ESLint scope 解析で未解決 read を抽出 ──
+const linter = new Linter();
+const rule = {
+    create(context) {
+        return {
+            'Program:exit'() {
+                const sm = context.sourceCode.scopeManager;
+                for (const ref of sm.globalScope.through) {
+                    if (ref.isRead() && !ref.resolved) {
+                        context.report({ node: ref.identifier, message: ref.identifier.name });
+                    }
+                }
+            },
+        };
+    },
+};
+const config = {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    plugins: { scan: { rules: { undeclaredRead: rule } } },
+    rules: { 'scan/undeclaredRead': 'error' },
+};
+
+const hits = {};
+let parseErrors = 0;
+let skippedDeadFile = 0;
+for (const f of files) {
+    const rel = f.replace(ROOT + '/', '');
+    if (DEAD_FILE_ALLOWLIST.has(rel)) { skippedDeadFile++; continue; }
+    let msgs;
+    try { msgs = linter.verify(readFileSync(f, 'utf8'), config); }
+    catch { parseErrors++; continue; }
+    for (const m of msgs) {
+        if (m.fatal) { parseErrors++; continue; }
+        const n = m.message;
+        if (BUILTINS.has(n)) continue;
+        if (enumNames.has(n)) continue;      // DefineEnum が実行時生成
+        if (hostGlobals.has(n)) continue;    // classic script / TS 層のグローバル
+        if (REGISTRY_IF.has(n)) continue;
+        if (DEAD_CODE_ALLOWLIST.has(n)) continue;
+        (hits[n] ||= []).push(`${rel}:${m.line}`);
+    }
+}
+
+const names = Object.keys(hits).sort();
+console.log(
+    `scanned ${files.length - skippedDeadFile} files (parseErrors=${parseErrors}), ` +
+    `enum-known=${enumNames.size}, host-globals=${hostGlobals.size}, dead-files-skipped=${skippedDeadFile}`
+);
+if (names.length === 0) {
+    console.log('✓ 未宣言変数の読み取りは検出されませんでした。');
+    process.exit(0);
+}
+console.log(`\n✗ 未宣言読み取りの疑い ${names.length} 種（ESM strict mode で ReferenceError）:`);
+for (const n of names) console.log(`  ${n}  ${hits[n].join(', ')}`);
+process.exit(1);


### PR DESCRIPTION
ESM は常に strict mode のため未定義識別子の bare read は実行時 ReferenceError になるが、 既存の scan-undeclared-writes.mjs は write のみを検査し read を明示的に無視していたため、 「特定のスキル・装備を選んだときだけ落ちる」バグが integration 全緑のまま潜伏していた。

- head.js: SU_AGI/VIT/INT/DEX/LUK の import 漏れ（SU_STR のみ import 済み）20箇所
- CSkillManager.js: カートキャノン威力式の powCart を powCard と誤記
- head.js: マススパイラルが mob.js の関数ローカル変数 B_Original_DEF を参照していた （初期コミットでは暗黙グローバル。移行時の var 付与で断線） → 同値を持つ mobData[MONSTER_DATA_INDEX_DEF_DIV_IGNORE_BUFF] に置換
- hmrndopt.js: 未宣言の pureStatusValue → 同一内容の pureParamArray に統一
- saveload.js: 初期コミットから未定義の n_CONFIG_SW が SaveCookieConf を中断させ、 旧 ConfData クッキー保持者のセーブデータ読込を失敗させていた → 未実行の98行を除去
- CShadowEquipController.js: getEqprgnNames の仮引数名と本体の不一致

対になる scan-undeclared-reads.mjs を新設。pnpm scan:undeclared で write/read 両方を検査する。