### PR TITLE
feat(tom-select): ↑↓ キーで Enter 無しに選択を確定できるようにする (#1496)

### DIFF
--- a/lib/tom-select/tom-select.custom.js
+++ b/lib/tom-select/tom-select.custom.js
@@ -39,11 +39,128 @@ TomSelect.define('dropdown_input', window.dropdown_input);
 
 // コンパクト表示 CSS は tom-select.custom.css に切り出し、各 HTML から <link> で読み込む。
 
+// キーボード操作でドロップダウンを開かずに ↑↓ で確定するための定数（#1496）。
+const KEY_HOME = 36;
+const KEY_END = 35;
+const KEY_UP = 38;
+const KEY_DOWN = 40;
+const KEY_SPACE = 32;
+const KEY_IME_PROCESS = 229; // IME 変換中の keydown（Chrome / Edge 等）
+
+// キーボードによる確定処理の実行中フラグ。
+// 確定は native 'change' を発火させ、それが LoadTomSelect() の再帰を招くため、
+// document 'change' リスナー側でこのフラグを見て再初期化をまとめる（後述）。
+let g_tomSelectKeyStepping = false;
+
+// キーリピート中に LoadTomSelect() の実行をまとめるためのタイマー。
+// 矢印キーで装備を送るたびに 34 個すべてを破棄・再構築すると連打に追従できないため、
+// 押下が続いている間は 1 回にまとめ、押下が止まってから反映する。
+let g_loadTomSelectTimer = 0;
+const REINIT_COALESCE_MS = 120;
+
+/**
+ * DOM の option 値集合と TomSelect の options dict のキー集合を比較する。
+ *
+ * 空値 ("") は TomSelect が未選択時に作るダミーであり options dict には
+ * 含まれないため、比較から除外する。
+ * @param {HTMLSelectElement} el
+ * @param {object} ts TomSelect インスタンス
+ * @returns {boolean} オプション集合が一致していれば true
+ */
+function IsSameOptionSet(el, ts) {
+    const tsOpts = ts.options;
+    const curVals = new Set(Array.from(el.options).map(o => String(o.value)).filter(v => v !== ''));
+    const tsVals = new Set(Object.keys(tsOpts));
+    return curVals.size === tsVals.size &&
+        [...curVals].every(v => tsVals.has(v) || tsVals.has(encodeURIComponent(v)));
+}
+
+/**
+ * ユーザーが今まさに操作している（フォーカス中 or ドロップダウンが開いている）か判定する。
+ * @param {object} ts TomSelect インスタンス
+ * @returns {boolean}
+ */
+function IsBusyTomSelect(ts) {
+    if (!ts) return false;
+    if (ts.isOpen || ts.isFocused) return true;
+    return !!(ts.wrapper && ts.wrapper.contains(document.activeElement));
+}
+
+/**
+ * 操作が終わる（blur する）まで再初期化を先送りする。
+ *
+ * destroy() 済みでない間は el.tomselect が生きたままなので、
+ * 先送り中に他経路（LoadTomSelect() の再実行等）で作り直されても
+ * el.tomselect !== ts の比較で二重初期化を防げる。
+ * @param {string} select_id LoadTomSelectSpecify に渡ったセレクタ文字列
+ * @param {HTMLSelectElement} el
+ * @param {object} ts TomSelect インスタンス
+ */
+function DeferReinitUntilBlur(select_id, el, ts) {
+    if (ts.__roReinitPending) return;
+    ts.__roReinitPending = true;
+    ts.on('blur', () => {
+        setTimeout(() => {
+            if (!el.isConnected || el.tomselect !== ts) return;
+            if (IsBusyTomSelect(ts)) return;
+            LoadTomSelectSpecify(select_id);
+        }, 0);
+    });
+}
+
+/**
+ * 単一の select 要素に対して TomSelect インスタンスを新規構築する。
+ * @param {HTMLSelectElement} el
+ */
+function InitTomSelectInstance(el) {
+    const ts = new TomSelect(el, {
+        maxOptions: null,
+        // Tab でフォーカスしただけではドロップダウンを開かない（ネイティブ select 準拠・#1496）。
+        // 開く手段は Alt+↑↓ / Space / クリック（下記 onClick フックと keydown リスナーで担保）。
+        openOnFocus: false,
+        plugins: ['dropdown_input'],
+    });
+    // 検索欄が空の状態で DEL を押しても選択値を消去しない
+    // （存在しない空文字が 'change' で流れてゲームロジックがクラッシュするため）
+    ts.deleteSelection = () => false;
+
+    // openOnFocus:false にすると素の onClick() は focus() するだけで開かなくなるため、
+    // クリックで開く挙動をここで明示的に補う（従来どおりトグル動作）。
+    ts.hook('instead', 'onClick', () => {
+        if (ts.activeItems.length > 0) {
+            ts.clearActiveItems();
+            ts.focus();
+            return;
+        }
+        if (ts.isFocused && ts.isOpen) {
+            ts.blur();
+            return;
+        }
+        OpenTomSelectDropdown(ts);
+    });
+}
+
+/**
+ * ドロップダウンを開き、現在値をハイライト・スクロール表示する。
+ * @param {object} ts TomSelect インスタンス
+ */
+function OpenTomSelectDropdown(ts) {
+    ts.focus();
+    ts.refreshOptions(true);
+}
+
 /**
  * 指定された select を TomSelect で初期化（再初期化時は既存インスタンスを破棄）
  *
  * destroy() は revertSettings.innerHTML を復元して el.value をリセットするため、
  * 事前に value と innerHTML を保存し、destroy 後に復元してから再初期化する。
+ *
+ * ただし、ユーザーが今まさに操作している（フォーカス中 or ドロップダウンが開いている）
+ * インスタンスを破棄すると wrapper ごと作り直されてフォーカスが失われ、矢印キーによる
+ * 連続確定操作が 1 回で途切れてしまう（#1496）。オプション集合・選択値のいずれも
+ * 変わっていない場合に限り、再初期化を blur まで先送りする。先送り中に DOM 順序が
+ * 汚れても、blur 後の destroy() が revertSettings.innerHTML（正しい50音順）を
+ * 復元するため崩れない。
  */
 function LoadTomSelectSpecify(select_id) {
     document.querySelectorAll(select_id).forEach(el => {
@@ -51,6 +168,7 @@ function LoadTomSelectSpecify(select_id) {
         try {
             const isEnchant = Array.from(el.options).some(o => o.text.includes('エンチャントなし'));
             if (el.tomselect) {
+                const ts = el.tomselect;
                 const savedValue = el.value;
                 // TomSelect の updateOriginalInput() は選択時に <option> を DOM 末尾へ移動する。
                 // ただし destroy() は revertSettings.innerHTML（sync() 前の正しい50音順）を
@@ -58,33 +176,26 @@ function LoadTomSelectSpecify(select_id) {
                 //
                 // オプションセットが変化した場合（ジョブ/武器種変更でゲームロジックが再構築）は
                 // destroy() で古い revertSettings が復元されてしまうため、現在の DOM を退避する。
-                //
-                // 空値 ("") は TomSelect が未選択時にダミーで作る option であり
-                // options dict には含まれないため比較から除外する。
-                const tsOpts = el.tomselect.options;
-                const curVals = new Set(Array.from(el.options).map(o => String(o.value)).filter(v => v !== ''));
-                const tsVals  = new Set(Object.keys(tsOpts));
-                const sameSet = curVals.size === tsVals.size &&
-                                [...curVals].every(v => tsVals.has(v) || tsVals.has(encodeURIComponent(v)));
+                const sameSet = IsSameOptionSet(el, ts);
+
+                if (sameSet && String(el.value) === String(ts.getValue()) && IsBusyTomSelect(ts)) {
+                    DeferReinitUntilBlur(select_id, el, ts);
+                    return;
+                }
+
                 if (sameSet) {
                     // destroy() が revertSettings.innerHTML（正しい50音順）を復元する。
-                    el.tomselect.destroy();
+                    ts.destroy();
                 } else {
                     // ゲームロジックが正しい50音順で再構築済みの DOM を退避・復元する。
                     const savedHTML = el.innerHTML;
-                    el.tomselect.destroy();
+                    ts.destroy();
                     el.innerHTML = savedHTML;
                 }
                 el.value = savedValue;
             }
             if (isEnchant) return;
-            const ts = new TomSelect(el, {
-                maxOptions: null,
-                plugins: ['dropdown_input'],
-            });
-            // 検索欄が空の状態で DEL を押しても選択値を消去しない
-            // （存在しない空文字が 'change' で流れてゲームロジックがクラッシュするため）
-            ts.deleteSelection = () => false;
+            InitTomSelectInstance(el);
         } catch (e) {
             console.warn('[TomSelect] init failed for', select_id, e);
         }
@@ -96,7 +207,21 @@ function LoadTomSelectSpecify(select_id) {
  * 画面初期化時などに呼ばれる
  */
 function LoadTomSelect() {
+    clearTimeout(g_loadTomSelectTimer);
+    g_loadTomSelectTimer = 0;
     SEARCHABLE_SELECT_LIST.forEach(LoadTomSelectSpecify);
+}
+
+/**
+ * キーリピート中は 34 個の破棄・再構築が押下間隔に追従できないため、
+ * 矢印キーによる確定が続いている間は LoadTomSelect() の実行をまとめる。
+ */
+function ScheduleLoadTomSelect() {
+    clearTimeout(g_loadTomSelectTimer);
+    g_loadTomSelectTimer = setTimeout(() => {
+        g_loadTomSelectTimer = 0;
+        LoadTomSelect();
+    }, REINIT_COALESCE_MS);
 }
 
 // 職業・装備変更時にカード選択欄が再生成されるため、
@@ -138,28 +263,115 @@ function LoadTomSelect() {
     // OnChangeJob やカスケード等は select 上のリスナーで先に完了しているため、
     // ここで LoadTomSelect() を呼ぶ時点では再生成済みの DOM が存在する。
     document.addEventListener('change', (e) => {
-        if (isTrigger(e.target)) {
-            LoadTomSelect();
+        if (!isTrigger(e.target)) return;
+        // 矢印キーによる確定中は、押下が続く間 34 個の再構築をまとめる。
+        if (g_tomSelectKeyStepping) {
+            ScheduleLoadTomSelect();
+            return;
         }
+        LoadTomSelect();
     });
+    // 先送り中に他の操作（クリック）が始まったら、古い表示のまま触らせないよう即座に反映する。
+    document.addEventListener('mousedown', () => {
+        if (g_loadTomSelectTimer) LoadTomSelect();
+    }, true);
 })();
+
+/**
+ * イベント発生元から TomSelect インスタンスを引く
+ * （Tom Select は元の select の直後に wrapper を挿入する）。
+ * @param {EventTarget} target
+ * @returns {object|null} TomSelect インスタンス
+ */
+function FindTomSelectFromEvent(target) {
+    if (!(target instanceof Element)) return null;
+    const wrapper = target.closest('.ts-wrapper');
+    if (!wrapper) return null;
+    const sel = wrapper.previousElementSibling;
+    return (sel && sel.tomselect) || null;
+}
+
+/**
+ * activeOption が未確定、または検索欄に残留した絞り込み文字列がある場合に、
+ * ドロップダウンを開かずに一覧を組み立てて現在値をハイライトする。
+ * @param {object} ts TomSelect インスタンス
+ */
+function EnsureActiveOption(ts) {
+    const hasStaleFilter = !!(ts.control_input && ts.control_input.value !== '');
+    if (hasStaleFilter) ts.control_input.value = '';
+    if (!hasStaleFilter && ts.activeOption && ts.dropdown_content.contains(ts.activeOption)) return;
+    ts.refreshOptions(false);
+}
+
+/**
+ * ハイライトされている option を、ドロップダウンの開閉状態を変えずに確定する
+ * （ネイティブ <select> の ↑↓ と同じ「Enter 不要」の操作感・#1496）。
+ *
+ * addItem() は closeAfterSelect が未設定だと単一選択モードで必ず close() する
+ * （tom-select.js の `settings.closeAfterSelect != false && isFull()` 判定）。
+ * close() は dropdown_input プラグインの before-close フックでフォーカスを
+ * control へ戻すため、キーリピート中はフォーカスが跳ねて操作が途切れる。
+ * このため確定処理の間だけ closeAfterSelect を固定し、開閉状態を変えない。
+ * クリックや Enter による確定はこの関数を通らないため挙動は従来どおり。
+ * @param {object} ts TomSelect インスタンス
+ * @param {Element} option data-selectable を持つドロップダウン内の要素
+ */
+function CommitActiveOption(ts, option) {
+    const value = option.dataset.value;
+    if (typeof value === 'undefined') return;
+    ts.setActiveOption(option);
+    const savedCloseAfterSelect = ts.settings.closeAfterSelect;
+    ts.settings.closeAfterSelect = false;
+    g_tomSelectKeyStepping = true;
+    try {
+        ts.addItem(value);
+    } finally {
+        g_tomSelectKeyStepping = false;
+        ts.settings.closeAfterSelect = savedCloseAfterSelect;
+    }
+}
 
 // HOME / END でドロップダウンのハイライトを先頭 / 末尾へ移動する。
 // 矢印キーは Tom Select 標準（開く / ハイライト移動）のまま。
 // Tom Select は HOME(36)/END(35) を処理しないため、ここで補完する。
-const KEY_END = 35;
-const KEY_HOME = 36;
 document.addEventListener('keydown', (e) => {
     if (e.keyCode !== KEY_HOME && e.keyCode !== KEY_END) return;
-    if (!(e.target instanceof Element)) return;
-    const wrapper = e.target.closest('.ts-wrapper');
-    if (!wrapper) return;
-    // Tom Select は元の <select> の直後に wrapper を挿入する
-    const sel = wrapper.previousElementSibling;
-    const ts = sel && sel.tomselect;
+    const ts = FindTomSelectFromEvent(e.target);
     if (!ts || !ts.isOpen) return;
     const opts = ts.dropdown_content.querySelectorAll('[data-selectable]');
     if (opts.length === 0) return;
     e.preventDefault();   // ページスクロール抑止
     ts.setActiveOption(e.keyCode === KEY_HOME ? opts[0] : opts[opts.length - 1]);
+}, true);
+
+// ↑ / ↓ はドロップダウンが閉じている間、開かずに前後の項目へ移動して即座に確定する
+// （ネイティブ <select> と同じ「Enter 不要」の操作感・#1496）。
+// 開いている間はハイライト移動のみという Tom Select 標準の挙動をそのまま使う
+// （確定は Enter・クリックのまま）。
+//
+// Alt+↑↓ / Space は「開くだけ」（ネイティブ <select> 準拠）。
+// Tom Select 標準の onKeyDown は KEY_DOWN（Alt の有無を見ない）でのみ open() し、
+// KEY_UP では開かない・Space は未対応（何もしないため既定でページスクロールする）。
+// ネイティブと挙動を合わせるため、ここで 3 つとも明示的に処理する。
+document.addEventListener('keydown', (e) => {
+    if (e.keyCode !== KEY_UP && e.keyCode !== KEY_DOWN && e.keyCode !== KEY_SPACE) return;
+    if (e.isComposing || e.keyCode === KEY_IME_PROCESS) return;   // IME 変換中は候補選択を優先
+    if (e.ctrlKey || e.metaKey) return;
+
+    const ts = FindTomSelectFromEvent(e.target);
+    if (!ts || ts.isOpen) return;   // 開いている時は Tom Select 標準 / 検索欄入力に任せる
+
+    if (e.altKey || e.keyCode === KEY_SPACE) {
+        e.preventDefault();    // Space によるページスクロール抑止
+        e.stopPropagation();
+        OpenTomSelectDropdown(ts);
+        return;
+    }
+
+    EnsureActiveOption(ts);
+    const next = ts.getAdjacent(ts.activeOption, e.keyCode === KEY_DOWN ? 1 : -1);
+    e.preventDefault();
+    e.stopPropagation();   // Tom Select 標準の onKeyDown（open()）を止める
+    if (!next) return;     // 端では何もしない（ネイティブ同様ラップしない）
+    CommitActiveOption(ts, next);
 }, true);

--- a/tests/integration/calcx.test.ts
+++ b/tests/integration/calcx.test.ts
@@ -676,6 +676,238 @@ describe('ro4/m/calcx.html 起動テスト', () => {
         }
     });
 
+    // ↑↓ キーで Enter 無しに TomSelect の選択を確定できることを確認する（#1496）。
+    // 開いた状態でハイライトを移動するだけでは Enter を押すまで反映されず、ネイティブ
+    // <select>（精錬値・超越等）との操作感の差が「使いにくい」という要望につながっていた。
+    // 加えて、確定は 'change' を発火させ document の change リスナーが LoadTomSelect() を
+    // 呼ぶため、素朴に実装すると操作中のインスタンス自身が壊れてフォーカスが失われ、
+    // 連続した ↓ 送りが 1 回で途切れる（destroy()/再構築の副作用）。
+    // 3 連打してもフォーカスが保持され、期待どおりの選択肢まで進むことを検証する。
+    it('装備セレクトで ↓ キーだけで値が確定・再計算され、連打してもフォーカスを保持する', async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, { waitUntil: 'networkidle', timeout: 60000 });
+            await page.waitForFunction(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as (HTMLSelectElement & { tomselect?: unknown }) | null;
+                return !!(el && el.tomselect);
+            }, { timeout: 15000 }).catch(() => {});
+            await page.waitForTimeout(300);
+
+            const setup = await page.evaluate(async () => {
+                const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+                type Sel = HTMLSelectElement & {
+                    tomselect?: { setValue(v: string): void; options: Record<string, unknown>; settings: { valueField: string } };
+                };
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as Sel | null;
+                if (!el || !el.tomselect) return null;
+                const ts = el.tomselect as any;
+                const ordered = Object.values(ts.options)
+                    .sort((a: any, b: any) => a.$order - b.$order)
+                    .map((o: any) => String(o[ts.settings.valueField]));
+                if (ordered.length < 5) return null;
+                // 先頭付近に固定し、3 手先まで送れる余地を確保する
+                ts.setValue(ordered[0]);
+                await sleep(300);
+                return { ordered, startValue: el.value };
+            });
+            if (!setup) {
+                console.warn('スキップ: OBJID_ARMS_RIGHT の選択肢を用意できない環境');
+                return;
+            }
+
+            await page.click('#OBJID_ARMS_RIGHT-ts-control');
+            await page.keyboard.press('Escape'); // 開いた状態を閉じてフォーカスだけ残す
+            await page.waitForTimeout(100);
+            const isOpenAfterEscape = await page.evaluate(
+                () => !!(document.getElementById('OBJID_ARMS_RIGHT') as any).tomselect?.isOpen
+            );
+            expect(isOpenAfterEscape, '閉じた状態から検証を始められなかった').toBe(false);
+
+            await page.keyboard.press('ArrowDown');
+            await page.keyboard.press('ArrowDown');
+            await page.keyboard.press('ArrowDown');
+            await page.waitForTimeout(300); // コアレスされた LoadTomSelect() / 再計算の完了を待つ
+
+            const result = await page.evaluate(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as (HTMLSelectElement & { tomselect?: any }) | null;
+                const wrapper = el?.nextElementSibling ?? null;
+                return {
+                    value: el?.value ?? '',
+                    isOpen: !!el?.tomselect?.isOpen,
+                    focusRetained: !!(wrapper && wrapper.contains(document.activeElement)),
+                };
+            });
+
+            expect(result.value, '↓ 3 回で 3 つ先の選択肢まで進んでいない').toBe(setup.ordered[3]);
+            expect(result.isOpen, 'リストが開いたままになっている').toBe(false);
+            expect(result.focusRetained, '連打の途中でフォーカスが失われた（再初期化で壊れた疑い）').toBe(true);
+        } finally {
+            await context.close();
+        }
+    });
+
+    // #1482「TomSelect再初期化時のoption末尾移動バグ」の回帰防止。
+    // ↓ キー確定は操作中インスタンスの再初期化を blur まで先送りする（#1496 実装）。
+    // 先送り中に DOM の option 順が崩れても、blur 後の destroy() が
+    // revertSettings.innerHTML（正しい50音順）を復元することを確認する。
+    it('↓ キーで確定を繰り返した後 blur すると option の DOM 順が50音順に戻る（#1482 回帰防止）', async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, { waitUntil: 'networkidle', timeout: 60000 });
+            await page.waitForFunction(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as (HTMLSelectElement & { tomselect?: unknown }) | null;
+                return !!(el && el.tomselect);
+            }, { timeout: 15000 }).catch(() => {});
+            await page.waitForTimeout(300);
+
+            const setup = await page.evaluate(async () => {
+                const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as (HTMLSelectElement & { tomselect?: any }) | null;
+                if (!el || !el.tomselect) return null;
+                const ts = el.tomselect;
+                const orderedBefore = Array.from(el.options).map((o) => o.value).filter((v) => v !== '');
+                if (orderedBefore.length < 3) return null;
+                ts.setValue(orderedBefore[0]);
+                await sleep(300);
+                return { orderedBefore };
+            });
+            if (!setup) {
+                console.warn('スキップ: OBJID_ARMS_RIGHT の選択肢を用意できない環境');
+                return;
+            }
+
+            await page.click('#OBJID_ARMS_RIGHT-ts-control');
+            await page.keyboard.press('Escape');
+            await page.keyboard.press('ArrowDown');
+            await page.keyboard.press('ArrowDown');
+            await page.waitForTimeout(200);
+
+            // 別の要素へフォーカスを移して blur させ、先送りされていた再初期化を発火させる
+            await page.evaluate(() => (document.getElementById('OBJID_SELECT_JOB') as HTMLElement | null)?.focus());
+            await page.waitForTimeout(200);
+
+            const orderedAfter = await page.evaluate(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as HTMLSelectElement | null;
+                return el ? Array.from(el.options).map((o) => o.value).filter((v) => v !== '') : [];
+            });
+
+            expect(orderedAfter, '確定を繰り返した後、選択中の装備が DOM 末尾に残っている').toEqual(setup.orderedBefore);
+        } finally {
+            await context.close();
+        }
+    });
+
+    // カード選択欄は INIT_TRIGGER_IDS に含まれない（LoadTomSelect() の起点にならない）ため、
+    // 装備本体と異なる再初期化経路を通る。↓ キー確定がこちらでも同様に効くことを確認する。
+    it('カード選択欄（OBJID_ARMS_RIGHT_CARD_1）でも ↓ キーで即座に確定する', async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, { waitUntil: 'networkidle', timeout: 60000 });
+            await page.waitForFunction(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT_CARD_1') as (HTMLSelectElement & { tomselect?: unknown }) | null;
+                return !!(el && el.tomselect);
+            }, { timeout: 15000 }).catch(() => {});
+            await page.waitForTimeout(300);
+
+            const result = await page.evaluate(async () => {
+                const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+                const el = document.getElementById('OBJID_ARMS_RIGHT_CARD_1') as (HTMLSelectElement & { tomselect?: any }) | null;
+                if (!el || !el.tomselect) return null;
+                const ts = el.tomselect;
+                const ordered = Object.values(ts.options)
+                    .sort((a: any, b: any) => a.$order - b.$order)
+                    .map((o: any) => String(o[ts.settings.valueField]));
+                if (ordered.length < 2) return null;
+                ts.setValue(ordered[0]);
+                await sleep(300);
+                return { before: el.value, wantNext: ordered[1] };
+            });
+            if (!result) {
+                console.warn('スキップ: OBJID_ARMS_RIGHT_CARD_1 の選択肢を用意できない環境（未展開/カード不可の装備）');
+                return;
+            }
+
+            await page.click('#OBJID_ARMS_RIGHT_CARD_1-ts-control');
+            await page.keyboard.press('Escape');
+            await page.keyboard.press('ArrowDown');
+            await page.waitForTimeout(200);
+
+            const after = await page.evaluate(
+                () => (document.getElementById('OBJID_ARMS_RIGHT_CARD_1') as HTMLSelectElement | null)?.value ?? ''
+            );
+            expect(after, 'カード欄で ↓ による確定が効いていない').toBe(result.wantNext);
+        } finally {
+            await context.close();
+        }
+    });
+
+    // openOnFocus:false により Tab フォーカスだけでは開かないが、ネイティブ <select> と同じ
+    // 4 通りの手段（Alt+↓ / Alt+↑ / Space / クリック）では開く（#1496）。
+    // Tom Select 標準の onKeyDown は KEY_DOWN でしか open() しない（KEY_UP は開かず、
+    // Space は未対応でページスクロールしてしまう）ため、この 3 つは明示的に補っている。
+    it('Tab でフォーカスしてもドロップダウンは開かず、Alt+↑↓ / Space / クリックでは開く', async () => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        try {
+            await page.goto(`${baseUrl}/ro4/m/calcx.html`, { waitUntil: 'networkidle', timeout: 60000 });
+            await page.waitForFunction(() => {
+                const el = document.getElementById('OBJID_ARMS_RIGHT') as (HTMLSelectElement & { tomselect?: unknown }) | null;
+                return !!(el && el.tomselect);
+            }, { timeout: 15000 }).catch(() => {});
+            await page.waitForTimeout(300);
+
+            const isOpen = () => page.evaluate(
+                () => !!(document.getElementById('OBJID_ARMS_RIGHT') as any).tomselect?.isOpen
+            );
+            const focusControl = () => page.evaluate(() => {
+                const wrapper = document.getElementById('OBJID_ARMS_RIGHT')?.nextElementSibling as HTMLElement | null;
+                (wrapper?.querySelector('.ts-control') as HTMLElement | null)?.focus();
+            });
+
+            // Tab フォーカス相当（.focus() 直接呼び出し）では開かない
+            await focusControl();
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'Tab 相当のフォーカスだけでリストが開いてしまっている').toBe(false);
+
+            // Alt+↓ で開く
+            await page.keyboard.press('Alt+ArrowDown');
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'Alt+↓ でリストが開かない').toBe(true);
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'Escape の後で閉じていない（前提が崩れている）').toBe(false);
+
+            // Alt+↑ でも開く（Tom Select 標準の KEY_UP は開かないための明示対応）
+            await page.keyboard.press('Alt+ArrowUp');
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'Alt+↑ でリストが開かない').toBe(true);
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+
+            // Space で開き、かつページがスクロールしない（既定動作の抑止）
+            await focusControl();
+            await page.evaluate(() => window.scrollTo(0, 0));
+            const scrollBefore = await page.evaluate(() => window.scrollY);
+            await page.keyboard.press('Space');
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'Space でリストが開かない').toBe(true);
+            const scrollAfter = await page.evaluate(() => window.scrollY);
+            expect(scrollAfter, 'Space でページがスクロールしてしまっている').toBe(scrollBefore);
+            await page.keyboard.press('Escape');
+            await page.waitForTimeout(100);
+
+            // クリックでも開く（従来どおり）
+            await page.click('#OBJID_ARMS_RIGHT-ts-control');
+            await page.waitForTimeout(100);
+            expect(await isOpen(), 'クリックしてもリストが開かない（従来の挙動が壊れた）').toBe(true);
+        } finally {
+            await context.close();
+        }
+    });
+
     // 詠唱シミュレータ欄を展開し、スキル選択セレクトの change イベントで
     // ReferenceError が発生しないことを確認する。
     // dewindow フェーズで castsim.js の onChange 属性を addEventListener に切り替えた後、

--- a/tests/roro/tom-select-keynav.test.ts
+++ b/tests/roro/tom-select-keynav.test.ts
@@ -1,0 +1,405 @@
+/**
+ * lib/tom-select/tom-select.custom.js のユニットテスト（#1496: ↑↓ で Enter 無しに確定する）
+ *
+ * 本体は ESM ではない classic script（calcx.html に <script defer> で読み込まれる）のため、
+ * 実ファイルを読み込んで eval し、内部関数を戻り値として取り出して検証する。
+ * TomSelect は本番と同じ base ビルド（プラグイン非バンドル）を使う。
+ *
+ * 注意: 実行時に読み込まれる本番ビルドは vendored tom-select.min.js（v2.6.1）だが、
+ * テスト環境の依存パッケージは v2.6.2。本テストで触るフック点
+ * （onKeyDown 系・refreshOptions・getAdjacent・addItem・options/$order）は
+ * このスキューで変わっていない（.claude/context/tom-select.md 参照）。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+// @ts-expect-error -- vendored ビルドに型定義が無い
+import TomSelect from 'tom-select/base';
+
+const LIB_DIR = join(__dirname, '../../lib/tom-select');
+
+interface CustomApi {
+    LoadTomSelect(): void;
+    LoadTomSelectSpecify(select_id: string): void;
+    FindTomSelectFromEvent(target: EventTarget | null): any;
+}
+
+let dropdownInputLoaded = false;
+
+// tom-select.custom.js は document レベルに keydown/change/mousedown リスナーを
+// 直接登録する classic script のため、テストごとに読み込み直すとリスナーが
+// 積み上がってしまう（本番では <script defer> で 1 回しか読み込まれないため
+// 起きない、テストハーネス特有の問題）。読み込み中の登録を捕捉しておき、
+// afterEach で確実に除去する。
+let capturedListeners: Array<[string, EventListenerOrEventListenerObject, boolean | AddEventListenerOptions | undefined]> = [];
+
+function LoadCustomScript(): CustomApi {
+    if (!dropdownInputLoaded) {
+        const dropdownInputSrc = readFileSync(join(LIB_DIR, 'dropdown_input.js'), 'utf-8');
+        // eslint-disable-next-line no-new-func -- classic script を検証用に評価する
+        new Function(dropdownInputSrc)();
+        dropdownInputLoaded = true;
+    }
+    const customSrc = readFileSync(join(LIB_DIR, 'tom-select.custom.js'), 'utf-8');
+    const origAdd = document.addEventListener.bind(document);
+    document.addEventListener = ((type: string, listener: any, options?: any) => {
+        capturedListeners.push([type, listener, options]);
+        return origAdd(type, listener, options);
+    }) as typeof document.addEventListener;
+    try {
+        // eslint-disable-next-line no-new-func
+        return new Function(
+            'TomSelect', 'window', 'document',
+            `${customSrc}\nreturn { LoadTomSelect, LoadTomSelectSpecify, FindTomSelectFromEvent };`,
+        )(TomSelect, window, document);
+    } finally {
+        document.addEventListener = origAdd;
+    }
+}
+
+function BuildSelect(id: string, values: Array<[string, string]>): HTMLSelectElement {
+    const el = document.createElement('select');
+    el.id = id;
+    for (const [value, text] of values) {
+        const opt = document.createElement('option');
+        opt.value = value;
+        opt.text = text;
+        el.appendChild(opt);
+    }
+    document.body.appendChild(el);
+    return el;
+}
+
+function DispatchKey(target: EventTarget, keyCode: number, extra: Record<string, unknown> = {}): void {
+    const evt = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...extra });
+    // happy-dom は KeyboardEvent コンストラクタ引数から keyCode を反映しないため明示的に定義する
+    Object.defineProperty(evt, 'keyCode', { get: () => keyCode });
+    target.dispatchEvent(evt);
+}
+
+type TSInstance = HTMLSelectElement & { tomselect: any };
+
+describe('tom-select.custom.js ↑↓ で即座に確定する（#1496）', () => {
+    let api: CustomApi;
+
+    beforeEach(() => {
+        api = LoadCustomScript();
+    });
+
+    afterEach(() => {
+        for (const [type, listener, options] of capturedListeners) {
+            document.removeEventListener(type, listener, options);
+        }
+        capturedListeners = [];
+        document.body.innerHTML = '';
+        vi.useRealTimers();
+    });
+
+    it('閉じた状態で ↓ を押すと次の option が確定し change が 1 回だけ発火する', () => {
+        const el = BuildSelect('test-down', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-down');
+        const ts = (el as TSInstance).tomselect;
+
+        let changeCount = 0;
+        el.addEventListener('change', () => { changeCount++; });
+
+        ts.control.focus();
+        expect(ts.isOpen).toBe(false);
+
+        DispatchKey(ts.control, 40); // ArrowDown
+
+        expect(el.value).toBe('2');
+        expect(ts.isOpen).toBe(false);
+        expect(changeCount).toBe(1);
+    });
+
+    it('閉じた状態で ↑ を押すと前の option へ戻る', () => {
+        const el = BuildSelect('test-up', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '2';
+        api.LoadTomSelectSpecify('#test-up');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 38); // ArrowUp
+
+        expect(el.value).toBe('1');
+    });
+
+    it('末尾の option で ↓ を押しても値は変わらない（ラップしない）', () => {
+        const el = BuildSelect('test-end', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '3';
+        api.LoadTomSelectSpecify('#test-end');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40);
+
+        expect(el.value).toBe('3');
+    });
+
+    it('先頭の option で ↑ を押しても値は変わらない（ラップしない）', () => {
+        const el = BuildSelect('test-start', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-start');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 38);
+
+        expect(el.value).toBe('1');
+    });
+
+    it('↓ を 3 回押すと 3 つ先の option が選択される', () => {
+        const el = BuildSelect('test-triple', [
+            ['1', 'あ'], ['2', 'い'], ['3', 'う'], ['4', 'え'], ['5', 'お'],
+        ]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-triple');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40);
+        DispatchKey(ts.control, 40);
+        DispatchKey(ts.control, 40);
+
+        expect(el.value).toBe('4');
+    });
+
+    it('Alt+↓ は確定せずドロップダウンを開くだけ', () => {
+        const el = BuildSelect('test-alt-down', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-alt-down');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40, { altKey: true });
+
+        expect(el.value).toBe('1');
+        expect(ts.isOpen).toBe(true);
+    });
+
+    it('Alt+↑ でも確定せずドロップダウンを開く（Tom Select 標準の KEY_UP は開かないため明示対応・要修正確認）', () => {
+        const el = BuildSelect('test-alt-up', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-alt-up');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 38, { altKey: true });
+
+        expect(el.value).toBe('1');
+        expect(ts.isOpen).toBe(true);
+    });
+
+    it('Space でドロップダウンが開き、既定のページスクロールが抑止される', () => {
+        const el = BuildSelect('test-space', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-space');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        const evt = new KeyboardEvent('keydown', { bubbles: true, cancelable: true });
+        Object.defineProperty(evt, 'keyCode', { get: () => 32 });
+        ts.control.dispatchEvent(evt);
+
+        expect(el.value).toBe('1');
+        expect(ts.isOpen).toBe(true);
+        expect(evt.defaultPrevented).toBe(true);
+    });
+
+    it('開いている間の Space は検索欄への入力として扱われ、横取りされない', () => {
+        const el = BuildSelect('test-space-open', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-space-open');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        ts.open();
+        const evt = new KeyboardEvent('keydown', { bubbles: true, cancelable: true });
+        Object.defineProperty(evt, 'keyCode', { get: () => 32 });
+        ts.control_input.dispatchEvent(evt);
+
+        expect(evt.defaultPrevented).toBe(false);
+    });
+
+    it('IME 変換中（isComposing）の ↓ は確定しない', () => {
+        const el = BuildSelect('test-ime', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-ime');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40, { isComposing: true });
+
+        expect(el.value).toBe('1');
+    });
+
+    it('IME 変換中（keyCode 229）の ↓ は確定しない', () => {
+        const el = BuildSelect('test-ime229', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-ime229');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 229);
+
+        expect(el.value).toBe('1');
+    });
+
+    it('ドロップダウンが開いている間の ↓ は Tom Select 標準どおりハイライト移動のみで確定しない', () => {
+        const el = BuildSelect('test-open', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-open');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        ts.open();
+        expect(ts.isOpen).toBe(true);
+
+        DispatchKey(ts.control, 40);
+
+        // 確定はしない（値は変わらない）が、ハイライトは Tom Select 標準の処理で移動しうる
+        expect(el.value).toBe('1');
+    });
+
+    it('disabled な option は ↓ でスキップされる', () => {
+        const el = BuildSelect('test-disabled', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        (el.options[1] as HTMLOptionElement).disabled = true; // 'い' を無効化
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-disabled');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40);
+
+        expect(el.value).toBe('3');
+    });
+
+    it('optgroup をまたいで ↓ が次の選択肢へ進む（グループ見出しはスキップされる）', () => {
+        const el = document.createElement('select');
+        el.id = 'test-optgroup';
+        const g1 = document.createElement('optgroup');
+        g1.label = 'グループ1';
+        const o1 = document.createElement('option');
+        o1.value = '1';
+        o1.text = 'あ';
+        g1.appendChild(o1);
+        const g2 = document.createElement('optgroup');
+        g2.label = 'グループ2';
+        const o2 = document.createElement('option');
+        o2.value = '2';
+        o2.text = 'い';
+        g2.appendChild(o2);
+        el.appendChild(g1);
+        el.appendChild(g2);
+        document.body.appendChild(el);
+        el.value = '1';
+
+        api.LoadTomSelectSpecify('#test-optgroup');
+        const ts = (el as TSInstance).tomselect;
+
+        ts.control.focus();
+        DispatchKey(ts.control, 40);
+
+        expect(el.value).toBe('2');
+    });
+
+    it('操作中（フォーカス中）の select は LoadTomSelect() で作り直されない', () => {
+        const el = BuildSelect('test-busy', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-busy');
+        const ts1 = (el as TSInstance).tomselect;
+
+        ts1.control.focus();
+        expect(document.activeElement === ts1.control || ts1.wrapper.contains(document.activeElement)).toBe(true);
+
+        // ゲームロジックが LoadTomSelect() 相当の再初期化を呼んだ状況を再現する
+        api.LoadTomSelectSpecify('#test-busy');
+
+        expect((el as TSInstance).tomselect).toBe(ts1); // 同一インスタンスのまま
+    });
+
+    it('操作していない select は sameSet でも通常どおり再構築される', () => {
+        const el = BuildSelect('test-idle', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-idle');
+        const ts1 = (el as TSInstance).tomselect;
+        (document.activeElement as HTMLElement | null)?.blur?.();
+
+        api.LoadTomSelectSpecify('#test-idle');
+
+        expect((el as TSInstance).tomselect).not.toBe(ts1);
+    });
+
+    it('blur すると先送りしていた再初期化が実行される', async () => {
+        const el = BuildSelect('test-defer', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-defer');
+        const ts1 = (el as TSInstance).tomselect;
+
+        ts1.control.focus();
+        api.LoadTomSelectSpecify('#test-defer'); // 先送りされる
+        expect((el as TSInstance).tomselect).toBe(ts1);
+
+        ts1.blur();
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect((el as TSInstance).tomselect).not.toBe(ts1);
+    });
+
+    it('先送り再初期化の後も deleteSelection の無効化パッチが維持される', async () => {
+        const el = BuildSelect('test-defer-del', [['1', 'あ'], ['2', 'い'], ['3', 'う']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-defer-del');
+        const ts1 = (el as TSInstance).tomselect;
+
+        ts1.control.focus();
+        api.LoadTomSelectSpecify('#test-defer-del');
+        ts1.blur();
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect((el as TSInstance).tomselect.deleteSelection()).toBe(false);
+    });
+
+    it('#1482 回帰: 矢印確定を繰り返しても再初期化後に option の DOM 順が 50音順へ戻る', async () => {
+        const el = BuildSelect('test-order', [['1', 'あ'], ['2', 'い'], ['3', 'う'], ['4', 'え']]);
+        el.value = '1';
+        api.LoadTomSelectSpecify('#test-order');
+        const ts1 = (el as TSInstance).tomselect;
+
+        ts1.control.focus();
+        DispatchKey(ts1.control, 40);
+        DispatchKey(ts1.control, 40);
+        DispatchKey(ts1.control, 40);
+        expect(el.value).toBe('4');
+
+        ts1.blur();
+        await new Promise((r) => setTimeout(r, 0));
+
+        const order = Array.from(el.options).map((o) => o.value).filter((v) => v !== '');
+        expect(order).toEqual(['1', '2', '3', '4']);
+    });
+
+    it('ネイティブ select（.ts-wrapper の外）の ↑↓ は横取りされない', () => {
+        const el = document.createElement('select');
+        el.id = 'test-native';
+        for (const [value, text] of [['1', 'あ'], ['2', 'い']] as Array<[string, string]>) {
+            const opt = document.createElement('option');
+            opt.value = value;
+            opt.text = text;
+            el.appendChild(opt);
+        }
+        document.body.appendChild(el);
+        el.value = '1';
+
+        let changeCount = 0;
+        el.addEventListener('change', () => { changeCount++; });
+
+        el.focus();
+        DispatchKey(el, 40);
+
+        // Tom Select 化されていないので、このリスナーは何もしない
+        expect(changeCount).toBe(0);
+    });
+});


### PR DESCRIPTION
ネイティブ `<select>`（精錬値・超越）は ↑↓ で値が即確定して再計算まで走るが、 TomSelect 化した装備 / カード / 職業欄は ↓ がドロップダウンを開くだけで、 Enter を押すまで確定しなかった。装備効果を素早く比較したいという要望に応える。

- 閉じた状態の ↑↓ を document キャプチャフェーズで横取りし、開閉状態を 変えずに addItem() で確定する。確定中だけ closeAfterSelect を固定して フォーカスの跳ね返りを防ぐ（クリック / Enter の挙動は従来どおり）。
- openOnFocus:false により Tab フォーカスでは開かなくなる副作用を、 onClick フックでクリック開閉を明示的に補って解消。
- 確定は change を発火させ LoadTomSelect() が操作中インスタンス自身を 壊す問題があったため、busy 判定で blur まで再初期化を先送りする。 DOM 順の汚れは blur 後の destroy() が復元するため #1482 は再発しない。
- キーリピート中の LoadTomSelect()（34 個の破棄・再構築）を 120ms まとめる。