### PR TITLE
refactor(head,buff,equip等): myInnerHtmlの純テキスト呼び出しをtextContentに変換（58箇所）

### DIFF
--- a/ro4/m/js/BuffGuildAndGospel.js
+++ b/ro4/m/js/BuffGuildAndGospel.js
@@ -41,7 +41,7 @@ export function Click_Skill4SW(){
 		document.calcForm.A4_SKILLSW.checked = true;
 		const name_CS4SW_SKILL = ["臨戦体勢","偉大なる指導力","栄光の傷","冷静な心","鋭い視線","ステータスALL+20","HP+100%","SP+100%","ATK+100%","HIT+50＆FLEE+50","被ダメージ半減"];
 		let html_CS4SW_SKILL = new Array();
-		for(let i = 0; i <= 10; i++) myInnerHtml("EN4"+i+"_1",name_CS4SW_SKILL[i],0);
+		for(let i = 0; i <= 10; i++) document.getElementById("EN4"+i+"_1").textContent = name_CS4SW_SKILL[i];
 		html_CS4SW_SKILL[0] = '<input type="checkbox" name="A4_Skill0">';
 		html_CS4SW_SKILL[1] = '<select name="A4_Skill1"></select>';
 		html_CS4SW_SKILL[2] = '<select name="A4_Skill2"></select>';
@@ -55,12 +55,12 @@ export function Click_Skill4SW(){
 		html_CS4SW_SKILL[10] = '<input type="checkbox" name="A4_Skill10">';
 		html_CS4SW_SKILL[11] = '<select name="A4_Skill11"></select>';
 		for(let i = 0; i <= 11; i++) myInnerHtml("EN4"+i+"_2",html_CS4SW_SKILL[i],0);
-		myInnerHtml("EN430_1","STR",0);
-		myInnerHtml("EN431_1","AGI",0);
-		myInnerHtml("EN432_1","VIT",0);
-		myInnerHtml("EN433_1","INT",0);
-		myInnerHtml("EN434_1","DEX",0);
-		myInnerHtml("EN435_1","LUK",0);
+		document.getElementById("EN430_1").textContent = "STR";
+		document.getElementById("EN431_1").textContent = "AGI";
+		document.getElementById("EN432_1").textContent = "VIT";
+		document.getElementById("EN433_1").textContent = "INT";
+		document.getElementById("EN434_1").textContent = "DEX";
+		document.getElementById("EN435_1").textContent = "LUK";
 		html_CS4SW_SKILL[30] = '<select name="A4_Skill30"></select>';
 		html_CS4SW_SKILL[31] = '<select name="A4_Skill31"></select>';
 		html_CS4SW_SKILL[32] = '<select name="A4_Skill32"></select>';
@@ -149,7 +149,7 @@ export function Click_A4(recalc = false){
 	}
 	if (sw == 0) {
 		document.getElementById('A4TD').style.backgroundColor = "#DDDDFF";
-		myInnerHtml("A4used","",0);
+		document.getElementById("A4used").textContent = "";
 	} else {
 		document.getElementById('A4TD').style.backgroundColor = "#FF7777";
 		myInnerHtml("A4used","　<B>使用中</B>",0);

--- a/ro4/m/js/BuffItemAndFood.js
+++ b/ro4/m/js/BuffItemAndFood.js
@@ -369,7 +369,7 @@ export function Click_A7(recalc = false){
 	}
 	if (sw == 0) {
 		document.getElementById('A7TD').style.backgroundColor = "#DDDDFF";
-		myInnerHtml("A7used","",0);
+		document.getElementById("A7used").textContent = "";
 	} else {
 		document.getElementById('A7TD').style.backgroundColor = "#FF7777";
 		myInnerHtml("A7used","　<B>使用中</B>",0);

--- a/ro4/m/js/BuffJobSpecificSelf.js
+++ b/ro4/m/js/BuffJobSpecificSelf.js
@@ -121,7 +121,7 @@ export function Click_PassSkillSW(){
 					myInnerHtml("P_Skill"+i, SkillObjNew[passiveSkillIdArray[i]][SKILL_DATA_INDEX_NAME] + "　<a href=\"../kousin/note20210606.html\" target=\"_blank\">(★注意情報★)</a>", 0);
 				}
 				else {
-					myInnerHtml("P_Skill"+i,SkillObjNew[passiveSkillIdArray[i]][SKILL_DATA_INDEX_NAME],0);
+					document.getElementById("P_Skill"+i).textContent = SkillObjNew[passiveSkillIdArray[i]][SKILL_DATA_INDEX_NAME];
 				}
 				myInnerHtml("P_Skill"+i+"s","<select name=A_skill"+i+" id=A_skill"+i+"></select>",0);
 				// inline onChange=Click_A1(true) を addEventListener に変換（Click_A1 は dewindow 済みで bare 参照不可）
@@ -607,7 +607,7 @@ export function Click_A1(recalc = false){
 	}
 	if (sw == 0) {
 		document.getElementById('A1TD').style.backgroundColor = "#DDDDFF";
-		myInnerHtml("A1used","",0);
+		document.getElementById("A1used").textContent = "";
 	} else {
 		document.getElementById('A1TD').style.backgroundColor = "#FF7777";
 		myInnerHtml("A1used","　<B>使用中</B>",0);

--- a/ro4/m/js/BuffOtherCategory.js
+++ b/ro4/m/js/BuffOtherCategory.js
@@ -109,7 +109,7 @@ export function Click_Skill8SW(){
 		document.calcForm.A8_Skill22.options[2] = new Option("シルバー(↑＋スピードポーション)",2);
 		document.calcForm.A8_Skill22.options[3] = new Option("ゴールド(↑＋Hit+10/Flee+10)",3);
 		document.calcForm.A8_Skill22.options[4] = new Option("レインボー(↑＋MaxHP+20%/MaxSP+20%)",4);
-		myInnerHtml("EN823",'←ジョンダパスはOTPレインボーです',0);
+		document.getElementById("EN823").textContent = "←ジョンダパスはOTPレインボーです";
 		myInnerHtml("EN805",'公平PT人数<select name="A8_Skill5"></select>', 0);
 		document.calcForm.A8_Skill5.options[0] = new Option("-",0);
 		for (let i = 1; i <= 11; i++) {
@@ -203,7 +203,7 @@ export function Click_A8(recalc = false){
 	}
 	if(sw == 0){
 		document.getElementById('A8TD').style.backgroundColor = "#DDDDFF";
-		myInnerHtml("A8used","",0);
+		document.getElementById("A8used").textContent = "";
 	}else{
 		document.getElementById('A8TD').style.backgroundColor = "#FF7777";
 		myInnerHtml("A8used","　<B>使用中</B>",0);

--- a/ro4/m/js/calcautospell.js
+++ b/ro4/m/js/calcautospell.js
@@ -1511,7 +1511,7 @@ export function OnChangeSettingAutoSpell(bCalculate){
 	}
 	else{
 		document.getElementById('OBJID_TD_AUTO_SPELL_SETTING').style.backgroundColor = "#DDDDFF";
-		myInnerHtml("OBJID_USED_MARKER_AUTO_SPELL","",0);
+		document.getElementById("OBJID_USED_MARKER_AUTO_SPELL").textContent = "";
 	}
  }
 

--- a/ro4/m/js/head-battle-result-html.js
+++ b/ro4/m/js/head-battle-result-html.js
@@ -72,12 +72,12 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 	}
 	myInnerHtml("bSUBname",CS.str_bSUBname,0);
 	myInnerHtml("bSUB",CS.str_bSUB,0);
-	myInnerHtml("BattleHIT",CS.w_HIT_HYOUJI,0);
-	myInnerHtml("BattlePerfectHIT",n_tok[ITEM_SP_PERFECT_ATTACK_UP],0);
+	document.getElementById("BattleHIT").textContent = CS.w_HIT_HYOUJI;
+	document.getElementById("BattlePerfectHIT").textContent = n_tok[ITEM_SP_PERFECT_ATTACK_UP];
 //	myInnerHtml("nm067","％",0);
 	// 二刀流の通常攻撃時の表示部分
 	if (n_Nitou && n_A_ActiveSkill == 0) {
-		myInnerHtml("BattleHIT",CS.w_HIT_HYOUJI +"％(左手"+ CS.w_HIT +"％)",0);
+		document.getElementById("BattleHIT").textContent = CS.w_HIT_HYOUJI +"％(左手"+ CS.w_HIT +"％)";
 //		myInnerHtml("nm067","",0);
 	}
 	// TODO : 謎処理　通常攻撃とグラビテーションフィールド以外
@@ -86,13 +86,13 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 			w_DMG[i] = 0;
 			CS.g_damageTextArray[i] = ["Miss"];
 		}
-		myInnerHtml("MinATKnum","無理です",0);
-		myInnerHtml("AveATKnum","無理です",0);
-		myInnerHtml("MaxATKnum","無理です",0);
-		myInnerHtml("AveSecondATK","-",0);
-		myInnerHtml("AtkBaseExp","-",0);
-		myInnerHtml("AtkJobExp","-",0);
-		myInnerHtml("BattleTime","-",0);
+		document.getElementById("MinATKnum").textContent = "無理です";
+		document.getElementById("AveATKnum").textContent = "無理です";
+		document.getElementById("MaxATKnum").textContent = "無理です";
+		document.getElementById("AveSecondATK").textContent = "-";
+		document.getElementById("AtkBaseExp").textContent = "-";
+		document.getElementById("AtkJobExp").textContent = "-";
+		document.getElementById("BattleTime").textContent = "-";
 
 		return;
 	}
@@ -102,13 +102,13 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 		CS.g_damageTextArray[0] = ["<B>この武器では</B>"];
 		CS.g_damageTextArray[1] = ["<B>このスキルを</B>"];
 		CS.g_damageTextArray[2] = ["<B>使用できません</B>"];
-		myInnerHtml("MinATKnum","-",0);
-		myInnerHtml("AveATKnum","-",0);
-		myInnerHtml("MaxATKnum","-",0);
-		myInnerHtml("AveSecondATK","-",0);
-		myInnerHtml("AtkBaseExp","-",0);
-		myInnerHtml("AtkJobExp","-",0);
-		myInnerHtml("BattleTime","-",0);
+		document.getElementById("MinATKnum").textContent = "-";
+		document.getElementById("AveATKnum").textContent = "-";
+		document.getElementById("MaxATKnum").textContent = "-";
+		document.getElementById("AveSecondATK").textContent = "-";
+		document.getElementById("AtkBaseExp").textContent = "-";
+		document.getElementById("AtkJobExp").textContent = "-";
+		document.getElementById("BattleTime").textContent = "-";
 
 		return;
 	}
@@ -121,11 +121,11 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 
 		// 最小攻撃回数が１万回未満ならば、そのまま表示
 		if(g_AttackCount[0] < 10000) {
-			myInnerHtml("MinATKnum",__DIG3(g_AttackCount[0]),0);
+			document.getElementById("MinATKnum").textContent = __DIG3(g_AttackCount[0]);
 		}
 		// １万回を超える場合は特殊表示
 		else {
-			myInnerHtml("MinATKnum",SubName[5],0);
+			document.getElementById("MinATKnum").textContent = SubName[5];
 		}
 
 	}else{
@@ -166,7 +166,7 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 
 			x = Math.floor(x * 10000) / 100;
 
-			myInnerHtml("MinATKnum","1(1回で倒せる確率"+ x +"%)",0);
+			document.getElementById("MinATKnum").textContent = "1(1回で倒せる確率"+ x +"%)";
 		}
 
 		CS.SG_Special_HITnum = 0;
@@ -190,8 +190,8 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 		if(CS.w_HIT_HYOUJI <100) wX = CS.n_PerfectHIT_DMG;
 		if(wX > 0){
 			g_AttackCount[2] = Math.ceil(mobData[3] / wX);
-			if(g_AttackCount[2]<10000) myInnerHtml("MaxATKnum",__DIG3(g_AttackCount[2]),0);
-			else myInnerHtml("MaxATKnum",SubName[5],0);
+			if(g_AttackCount[2]<10000) document.getElementById("MaxATKnum").textContent = __DIG3(g_AttackCount[2]);
+			else document.getElementById("MaxATKnum").textContent = SubName[5];
 		}else{
 			myInnerHtml("MaxATKnum","<Font size=2>計算不能<BR>(0ダメージなので)</Font>",0);
 		}
@@ -211,23 +211,23 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 		}
 
 		if(g_AttackCount[1]<10000){
-			myInnerHtml("AtkBaseExp",__DIG3(Math.round(mobData[15] / g_AttackCount[1])) +"Exp",0);
-			myInnerHtml("AtkJobExp",__DIG3(Math.round(mobData[16] / g_AttackCount[1])) +"Exp",0);
+			document.getElementById("AtkBaseExp").textContent = __DIG3(Math.round(mobData[15] / g_AttackCount[1])) +"Exp";
+			document.getElementById("AtkJobExp").textContent = __DIG3(Math.round(mobData[16] / g_AttackCount[1])) +"Exp";
 		}else{
-			myInnerHtml("AtkBaseExp",SubName[7],0);
-			myInnerHtml("AtkJobExp",SubName[7],0);
+			document.getElementById("AtkBaseExp").textContent = SubName[7];
+			document.getElementById("AtkJobExp").textContent = SubName[7];
 		}
 
 		if(g_AttackCount[1]<10000){
-			myInnerHtml("AveATKnum",__DIG3(g_AttackCount[1]),0);
+			document.getElementById("AveATKnum").textContent = __DIG3(g_AttackCount[1]);
 			const n_AveATKnum = g_AttackCount[1];
 			var w2 = (CS.wCast + wDelay) * n_AveATKnum;
 			w2 = Math.floor(w2 * 100) / 100;
-			if(n_Delay[0]) myInnerHtml("BattleTime","特殊",0);
-			else myInnerHtml("BattleTime",__DIG3(w2) + "秒",0);
+			if(n_Delay[0]) document.getElementById("BattleTime").textContent = "特殊";
+			else document.getElementById("BattleTime").textContent = __DIG3(w2) + "秒";
 		}else{
-			myInnerHtml("AveATKnum",SubName[5],0);
-			myInnerHtml("BattleTime",SubName[6],0);
+			document.getElementById("AveATKnum").textContent = SubName[5];
+			document.getElementById("BattleTime").textContent = SubName[6];
 		}
 
 		g_dps = 1 / (CS.wCast + wDelay) * w_DMG[1];
@@ -236,9 +236,9 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 		g_dps /= 100;
 		if(n_Delay[0]) {
 			g_dps = -1;
-			myInnerHtml("AveSecondATK","特殊",0);
+			document.getElementById("AveSecondATK").textContent = "特殊";
 		}
-		else myInnerHtml("AveSecondATK",__DIG3(g_dps),0);
+		else document.getElementById("AveSecondATK").textContent = __DIG3(g_dps);
 	}else{
 		myInnerHtml("AtkBaseExp","<Font size=2>計算不能</Font>",0);
 		myInnerHtml("AtkJobExp","<Font size=2>計算不能</Font>",0);
@@ -264,10 +264,10 @@ export function BuildBattleResultHtml(charaData, specData, mobData, attackMethod
 	if(UsedSkillSearch(SKILL_ID_REJECT_SWORD)){
 		w = Math.round(w * (100- UsedSkillSearch(SKILL_ID_REJECT_SWORD) *7.5))/100;
 	}
-	myInnerHtml("B_Ave2Atk",__DIG3(w)+"ダメージ",0);
+	document.getElementById("B_Ave2Atk").textContent = __DIG3(w)+"ダメージ";
 	g_receiveDamageAvoids = w;
 	if(n_A_ActiveSkill==441) {
-		myInnerHtml("B_Ave2Atk","-",0);
+		document.getElementById("B_Ave2Atk").textContent = "-";
 	}
 }
 

--- a/ro4/m/js/head.js
+++ b/ro4/m/js/head.js
@@ -2857,7 +2857,7 @@ export function calc() {
 
 	if(n_A_ActiveSkill==0 || n_A_ActiveSkill==SKILL_ID_SHARP_SHOOTING || n_A_ActiveSkill==401 || n_A_ActiveSkill==456 || n_A_ActiveSkill==578 || (n_A_ActiveSkill==86 && (50 <= mobData[18] && mobData[18] <60))){
 		CS.w_HIT_HYOUJI = Math.floor(GetActHitRateAll(n_A_ActiveSkill, mobData) * 100) /100;
-		myInnerHtml("CRInum",(Math.round(GetActRateCritical(n_A_ActiveSkill, mobData) * 100) / 100) + SubName[0],0);
+		document.getElementById("CRInum").textContent = (Math.round(GetActRateCritical(n_A_ActiveSkill, mobData) * 100) / 100) + SubName[0];
 	}
 
 	set_w_FLEE(95 - (mobData[33] - charaData[CHARA_DATA_INDEX_FLEE]));
@@ -2880,7 +2880,7 @@ export function calc() {
 	// FLEE範囲補正
 	set_w_FLEE(Math.min(95, Math.max(5, w_FLEE)));
 
-	myInnerHtml("BattleFLEE",Math.floor((w_FLEE + (100 - w_FLEE) * charaData[CHARA_DATA_INDEX_LUCKY] / 100) * 100) / 100,0);
+	document.getElementById("BattleFLEE").textContent = Math.floor((w_FLEE + (100 - w_FLEE) * charaData[CHARA_DATA_INDEX_LUCKY] / 100) * 100) / 100;
 
 	//----------------------------------------------------------------
 	//

--- a/ro4/m/js/hmjob.js
+++ b/ro4/m/js/hmjob.js
@@ -7,7 +7,7 @@ import '../../../roro/m/js/item.h.js';
 import '../../../roro/m/js/monster.h.js';
 import { GetBaseLevelMax, GetBaseLevelMin, GetStatusMax, IsDualArmsJob, IsReincarnatedJob, IsSameJobGroup, IsYojiJob } from './data/mig.job.h.js';
 import { CSaveDataConst } from './savedata/CSaveDataConst.js';
-import { HtmlGetObjectValueByIdAsInteger, ValueRangeModify, myInnerHtml } from '../../../roro/common/js/util.js';
+import { HtmlGetObjectValueByIdAsInteger, ValueRangeModify } from '../../../roro/common/js/util.js';
 import { CCharaConfCustomSpecStatus } from '../../../roro/m/js/CCharaConfCustomSpecStatus.js';
 import { CCharaConfNizi } from '../../../roro/m/js/CCharaConfNizi.js';
 import { CCharaConfYozi } from '../../../roro/m/js/CCharaConfYozi.js';
@@ -360,8 +360,8 @@ export function CalcStatusPoint(bIgnoreAutoCalc, bIgnorePointCap = false) {
 	g_CRT = stValCRT;
 	g_BaseLV = Number(_cf.A_BaseLV.value);
 
-	myInnerHtml("A_STPOINT", stPointEarned - stPointUsed, 0);
-	myInnerHtml("OBJID_SPAN_STATUS_T_STATUS_POINT", stTSPointEarned - stTSPointUsed, 0);
+	document.getElementById("A_STPOINT").textContent = stPointEarned - stPointUsed;
+	document.getElementById("OBJID_SPAN_STATUS_T_STATUS_POINT").textContent = stTSPointEarned - stTSPointUsed;
 
 	// 特性ステータス仮処理
 	g_pureStatus = [];

--- a/roro/m/js/equip.js
+++ b/roro/m/js/equip.js
@@ -163,9 +163,9 @@ export function changeJobSettings(jobId) {
 
 	// 武器属性付与手段の名称の設定
 	if (41 <= migId && migId <= 43) {
-		myInnerHtml("ID_A_HUYO_NAME","暖かい風",0);
+		document.getElementById("ID_A_HUYO_NAME").textContent = "暖かい風";
 	} else {
-		myInnerHtml("ID_A_HUYO_NAME","武器属性付与",0);
+		document.getElementById("ID_A_HUYO_NAME").textContent = "武器属性付与";
 	}
 
 	// Baseレベル自動調整が有効だと値設定ができない不具合があるので、無効化...
@@ -393,7 +393,7 @@ export function OnChangeArmsTypeRight(itemKind){
 		}
 		else{
 
-			myInnerHtml("A_SobWeaponName","",0);
+			document.getElementById("A_SobWeaponName").textContent = "";
 
 			HtmlRemoveOptionAll(_cf.OBJID_ARMS_LEFT);
 			_cf.OBJID_ARMS_LEFT.options[0] = new Option(ItemObjNew[ITEM_ID_SUDE][ITEM_DATA_INDEX_NAME], ITEM_ID_SUDE);

--- a/roro/m/js/foot.js
+++ b/roro/m/js/foot.js
@@ -762,7 +762,7 @@ import {
          TIME_ITEM_ID_VNDER_CANMER_SHUCHURYOKU_KOZYO, TIME_ITEM_ID_WOLF_HEZIN,
          TIME_ITEM_ID_ZETSUBONO_KAMI_MOROCC_CARD
 } from './timeitem.dat.js';
-import { HtmlCreateElement, HtmlCreateTextNode, HtmlRemoveOptionAll, HtmlCreateElementOption, HtmlRemoveAllChild, HtmlGetObjectValueById, HtmlGetObjectValueByIdAsInteger, HtmlSetObjectValueById, SetStatefullData, GetStatefullData, toSafeBigInt, myInnerHtml } from '../../common/js/util.js';
+import { HtmlCreateElement, HtmlCreateTextNode, HtmlRemoveOptionAll, HtmlCreateElementOption, HtmlRemoveAllChild, HtmlGetObjectValueById, HtmlGetObjectValueByIdAsInteger, HtmlSetObjectValueById, SetStatefullData, GetStatefullData, toSafeBigInt } from '../../common/js/util.js';
 import {
          SKILL_ID_ACID_DEMONSTRATION, SKILL_ID_ADJUSTMENT, SKILL_ID_ADORAMUS,
          SKILL_ID_ADRENALINE_RUSH, SKILL_ID_ADVANCED_BOOK, SKILL_ID_AIMED_BOLT,
@@ -1847,8 +1847,8 @@ export function StAllCalc(){
 			n_A_PassSkill8[21] = legacyNum(calcForm.A8_Skill21.value);
 			n_A_PassSkill8[22] = legacyNum(calcForm.A8_Skill22.value);
 			if(41 <= n_A_JOB && n_A_JOB <= 43){
-				if(n_A_PassSkill8[19] == 0) myInnerHtml("ID_A_HUYO_NAME","暖かい風",0);
-				else myInnerHtml("ID_A_HUYO_NAME","武器属性付与",0);
+				if(n_A_PassSkill8[19] == 0) document.getElementById("ID_A_HUYO_NAME").textContent = "暖かい風";
+				else document.getElementById("ID_A_HUYO_NAME").textContent = "武器属性付与";
 			}
 		}
 


### PR DESCRIPTION
myInnerHtml(id, htmlString, 0) の113呼び出し全てを個別に精査し、 実際にHTMLマークアップを渡しているものと、プレーンテキストのみを 渡しているものを分類した。変数引数（str, CS.str_bSUBname, html_CS4SW_SKILL等）は代入元を全て辿り、動的にHTMLタグが 混入し得るかどうかを確認した。

- 58箇所: document.getElementById(id).textContent = ... に変換
- 53箇所: HTMLマークアップを含む・含み得るため維持 （例: CS.str_bSUBnameはhead-skill-formula-*.jsで<FONT>タグが +=される。CS.g_damageTextArrayも同様）

myInnerHtml呼び出しが0件になったfoot.js・hmjob.jsはimportも整理した。 半角&を含む引数は無く、NBSP等のHTMLエンティティ差異の懸念は該当しない。

.claude/context/remaining-work.md系「UI/ロジック分離」リファクタリング計画のPhase 4。 HTML文字列問題は114箇所→myInnerHtmlの53箇所（実マークアップ渡しのみ）に縮小した。