### PR TITLE
refactor(head): スキル計算式内のA_Weapon_zokusei直読みをhydrate済み値に置換

### DIFF
--- a/ro4/m/js/head-skill-formula-magical.js
+++ b/ro4/m/js/head-skill-formula-magical.js
@@ -82,6 +82,7 @@ import {
     set_g_bDefinedDamageIntervals, set_n_A_Weapon_zokusei, set_n_Enekyori, w_DMG
 } from './ro4-state.js';
 import { UsedSkillSearch } from './skillstate.js';
+import { n_A_WeaponZokusei } from '../../../roro/m/js/roro-state.js';
 
 export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mobData, attackMethodConfArray, dmgUnit, bCri, bLeft) {
     let w_MATK = [0,0,0];
@@ -388,7 +389,7 @@ export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mo
 			break;
 
 		case SKILL_ID_ESTIN:
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			CS.wCast = 100;
 			n_Delay[2] = 500;
 			if(mobData[17] == 0) CS.wbairitu = 10 * n_A_ActiveSkillLV;
@@ -396,14 +397,14 @@ export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mo
 			break;
 
 		case SKILL_ID_ESTON:
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			CS.wCast = 100;
 			n_Delay[2] = 500;
 			CS.wbairitu = 5 * n_A_ActiveSkillLV;
 			break;
 
 		case SKILL_ID_ESMA:
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			n_Delay[0] = 1;
 			CS.wHITsuu = n_A_ActiveSkillLV;
 			CS.wCast = 2000;
@@ -862,7 +863,7 @@ export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mo
 			break;
 
 		case SKILL_ID_ESHA:
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			CS.wCast = 200 * n_A_ActiveSkillLV;
 			CS.n_KoteiCast = 200 * n_A_ActiveSkillLV;
 			n_Delay[7] = 1000;
@@ -871,7 +872,7 @@ export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mo
 			break;
 
 		case SKILL_ID_ESPA:
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			CS.wCast = 100 * n_A_ActiveSkillLV;
 			CS.n_KoteiCast = 100 * n_A_ActiveSkillLV;
 			CS.wbairitu = 500 + (250 * n_A_ActiveSkillLV);
@@ -882,7 +883,7 @@ export function ApplyMagicalSkillFormula(battleCalcInfo, charaData, specData, mo
 		case SKILL_ID_ESFU:
 			CS.n_bunkatuHIT = 1;
 			CS.wHITsuu = 5;
-			set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+			set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 			CS.wCast = 100 * n_A_ActiveSkillLV;
 			CS.n_KoteiCast = 100 * n_A_ActiveSkillLV;
 			CS.wbairitu = 1500 + (250 * n_A_ActiveSkillLV);

--- a/ro4/m/js/head-skill-formula-physical.js
+++ b/ro4/m/js/head-skill-formula-physical.js
@@ -129,6 +129,7 @@ import {
     set_g_bDefinedDamageIntervals, set_n_A_Weapon_zokusei, set_n_Enekyori, set_w_DMG, w_DMG
 } from './ro4-state.js';
 import { UsedSkillSearch } from './skillstate.js';
+import { n_A_WeaponZokusei } from '../../../roro/m/js/roro-state.js';
 
 export function ApplyPhysicalSkillFormulaBasic(battleCalcInfo, charaData, specData, mobData, attackMethodConfArray, dmgUnit, bCri, bLeft) {
     let ret = null;
@@ -902,7 +903,7 @@ export function ApplyPhysicalSkillFormulaBasic(battleCalcInfo, charaData, specDa
 				CS.wbairitu = (n_A_ActiveSkillLV - 1) * (n_A_AGI / 2) + 300;
 				CS.wbairitu = ROUNDDOWN(CS.wbairitu * n_A_BaseLV / 120);
 				set_n_A_Weapon_zokusei(GetEquippedTotalSPArrow(ITEM_SP_ELEMENTAL));
-				if(eval(document.calcForm.A_Weapon_zokusei.value) != 0) set_n_A_Weapon_zokusei(eval(document.calcForm.A_Weapon_zokusei.value));
+				if(n_A_WeaponZokusei != 0) set_n_A_Weapon_zokusei(n_A_WeaponZokusei);
 				set_n_Enekyori(1);
 				CS.wCast = 5000 - 500 * n_A_ActiveSkillLV;
 				n_Delay[2] = 500 - 50 * n_A_ActiveSkillLV;

--- a/tests/helpers/objid-snapshot.ts
+++ b/tests/helpers/objid-snapshot.ts
@@ -269,7 +269,7 @@ const STATE_MODULE_PATHS = [
  * 例: `global.js` の `g_skillManager`）は落とさず `'[unserializable]'` として記録する
  * （こういうフィールドは通常2回の hydration 間で値が変わらないため、diff には出現しない）。
  *
- * hydration の冪等性（`foot.js:1929-1933` で `n_tok` 等を都度ゼロクリアしてから積算する）が
+ * hydration の冪等性（`foot.js:1438-1441` で `n_tok` 等を都度ゼロクリアしてから積算する）が
  * 前提。連続呼び出しで値が累積することはない。
  */
 export function snapshotAllGlobals(page: Page): Promise<Record<string, string>> {


### PR DESCRIPTION
head-skill-formula-{magical,physical}.jsの7箇所がdocument.calcFormを 再読みしていた。foot-stallcalc-hydrate.jsが既に同一DOM要素から n_A_WeaponZokusei(roro-state.js)へhydrate済みのため、そちらを読むだけに 変更。書き込み元がhydrate.js 1箇所のみであることをgrepで確認済み。 Phase 8(モデル導入)の前提条件。