### PR TITLE
refactor(foot): StAllCalcのhydrationをモデル境界で分離

### DIFF
--- a/roro/m/js/calc-model.js
+++ b/roro/m/js/calc-model.js
@@ -1,0 +1,88 @@
+/**
+ * StAllCalc の入力を表すプレーンなモデル（リファクタリング計画 Phase 8）。
+ *
+ * `roro/m/js/foot-stallcalc-hydrate.js` の `HydrateFromDom()` が `document.calcForm` から
+ * 直接読んでいた値のうち、**この hydrate ファイル自身が直接DOMから読んでいる値のみ**を
+ * 対象とする。以下は意図的にモデルへ含めない（既存グローバルを直接読む、
+ * 「境界の外側の既にhydrate済みの前提」として扱う）:
+ *
+ * - `n_A_JOB`（職業選択。`InitJobInfo()` 経由、別のUIフローで既にhydrate済み）
+ * - `n_Skill{1,4,7,8}SW`（バフパネルの開閉状態。各 `Buff*.js` のクリックハンドラが管理）
+ * - `CAttackMethodAreaComponentManager.GetAttackMethodConf()` の戻り値
+ *   （攻撃手段コンポーネント自身の内部状態。メソッドを持つオブジェクトで
+ *   プレーンなJSON化ができない）
+ * - `GetTotalSpecStatus(...)`（性能カスタマイズ欄の合計値。別コンポーネントの集計）
+ * - `g_shadowEquipController.getEquippedID/getRefined/getRndOptInfoArray(...)`
+ *   （シャドウ装備コンポーネント自身の内部状態）
+ *
+ * 判定基準: 「hydrate.js が `document.calcForm.X` / `HtmlGetObjectValueById(Id, default)` /
+ * `GetStatefullData(Id, default)` を**直接**呼んで得ている値」だけがモデルに入る。
+ * 他のマネージャ/コンポーネントの getter 経由で得ている値は、`foot-stallcalc-*` 30モジュール
+ * 自身の読むグローバルと同じ扱い（モデルの外側・境界の内側の実装詳細）とする。
+ *
+ * 装備・カード・衣装欄は既存グローバル（`n_A_Equip` / `n_A_card` / `n_A_costume`）と
+ * 同じ「`EnumEquipRegionId.js` 等の定数で添字アクセスする配列」の形を踏襲する
+ * （named field に変換すると約45個のカード欄で転記ミスのリスクが上がるため、
+ * 既存の添字方式をそのまま流用するほうが安全）。
+ */
+
+/** @returns {object} 全フィールドを既定値で埋めたモデル */
+export function createEmptyModel() {
+    return {
+        /** 基本ステータス（A_BaseLV 等） */
+        status: {
+            baseLv: undefined,     // calcForm.A_BaseLV
+            jobLv: undefined,      // calcForm.A_JobLV
+            str: undefined,        // calcForm.A_STR
+            agi: undefined,        // calcForm.A_AGI
+            vit: undefined,        // calcForm.A_VIT
+            dex: undefined,        // calcForm.A_DEX
+            int: undefined,        // calcForm.A_INT
+            luk: undefined,        // calcForm.A_LUK
+            speedPot: undefined,   // calcForm.A_SpeedPOT
+        },
+        /** 武器関連（属性・精錬値等） */
+        weapon: {
+            type: undefined,                  // calcForm.A_WeaponType
+            zokusei: undefined,                // calcForm.A_Weapon_zokusei
+            atkPlus: undefined,                // calcForm.A_Weapon_ATKplus
+            transcendence: undefined,          // calcForm.A_Weapon_Transcendence
+            weapon2AtkPlus: undefined,         // calcForm.A_Weapon2_ATKplus
+            weapon2Transcendence: undefined,   // calcForm.A_Weapon2_Transcendence
+        },
+        /** 各部位の精錬値（+n） */
+        defPlus: {
+            head: undefined,       // calcForm.A_HEAD_DEF_PLUS
+            body: undefined,       // calcForm.A_BODY_DEF_PLUS
+            shield: undefined,     // calcForm.A_SHIELD_DEF_PLUS
+            shoulder: undefined,   // calcForm.A_SHOULDER_DEF_PLUS
+            shoes: undefined,      // calcForm.A_SHOES_DEF_PLUS
+        },
+        /** 各部位の超越段階 */
+        defTranscendence: {
+            head: undefined,       // calcForm.A_HEAD_DEF_Transcendence
+            shield: undefined,     // calcForm.A_SHIELD_DEF_Transcendence
+            body: undefined,       // calcForm.A_BODY_DEF_Transcendence
+            shoulder: undefined,   // calcForm.A_SHOULDER_DEF_Transcendence
+            shoes: undefined,      // calcForm.A_SHOES_DEF_Transcendence
+        },
+        /** 矢のID（OBJID_SELECT_ARROW） */
+        arrow: undefined,
+        /** 装備部位ごとのアイテムID配列（EQUIP_REGION_ID_* で添字アクセス） */
+        equip: [],
+        /** カード・エンチャント枠ごとのアイテムID配列（CARD_REGION_ID_* で添字アクセス） */
+        card: [],
+        /** 衣装欄のアイテムID配列（COSTUME_REGION_ID_* で添字アクセス） */
+        costume: [],
+        /** 職業スキル（パッシブ/持続系。A1欄）。長さは職業ごとに可変 */
+        passiveSkill: [],
+        /** オートスペル設定（AS_SKILL_ID/LV/PROB が同じ配列の異なるオフセット範囲に入る） */
+        autoSpell: [],
+        /** ギルドスキル/ゴスペル/他（A4欄）。n_A_PassSkill4 と同じ添字 */
+        buff4: Array(36).fill(0),
+        /** アイテム・食品他（A7欄）。n_A_PassSkill7 と同じ添字 */
+        buff7: Array(53).fill(0),
+        /** その他の支援/設定（A8欄）。n_A_PassSkill8 と同じ添字 */
+        buff8: Array(28).fill(0),
+    };
+}

--- a/roro/m/js/foot-stallcalc-hydrate.js
+++ b/roro/m/js/foot-stallcalc-hydrate.js
@@ -1,18 +1,17 @@
 /**
- * StAllCalc の DOM 走査プロローグ（リファクタリング計画 Phase 5）。
+ * StAllCalc の DOM 走査プロローグ（リファクタリング計画 Phase 5・Phase 8）。
  *
  * foot.js の StAllCalc は「DOM からグローバル状態へ書き込む」処理と「純粋な計算」処理が
- * 同一関数内に混在していた。本ファイルは前者（hydration）を HydrateFromDom() として
- * 切り出したもの（UpdateEquipItemDataByHtml 等の DOM 読み取りヘルパー3関数も、
- * hydration の一部であり StAllCalc 以外からは呼ばれていないため同時に移動した）。
+ * 同一関数内に混在していた。本ファイルは前者（hydration）を切り出したもの。
  *
- * 本文はバイト単位で不変（関数シグネチャ・新規のローカル変数宣言・末尾の return のみ新規）。
- * ただし分割にあたり、書き込まれるが一度も読まれないことを機械的に確認済みの
- * デッドコード（SU_POW/SU_STA/SU_WIS/SU_SPL/SU_CON/SU_CRT・n_A_POW・n_A_CON への代入、
- * および sandanDelay/vartmp/valary/sklLv/bufLv・itemCount系5個・cardCount系12個の
- * 未使用ローカル変数宣言）は分割を機に削除した（ユーザー承認済み）。
- * n_A_SpeedPOT と attackMethodConfArray は StAllCalcCore() 側でも読まれるため、
- * 戻り値として返す。
+ * Phase 5（初回分割）では `HydrateFromDom()` が直接 `document.calcForm` 等を読んでいたが、
+ * Phase 8 で「DOM を読む（ExtractModelFromDom）」と「モデルからグローバルへ書く
+ * （HydrateFromModel）」に分離した。`HydrateFromDom()` は両者を繋ぐ薄いラッパーとして残る
+ * （`calcx.html` 以外の呼び出し元・StAllCalc からの呼ばれ方は一切変えていない）。
+ *
+ * モデルの境界については `calc-model.js` の先頭コメントを参照。要約: hydrate.js が
+ * `document.calcForm` 等を**直接**読んでいる値だけがモデルに入る。他コンポーネント
+ * （攻撃手段・シャドウ装備・性能カスタマイズ合計値・職業選択）経由の値は境界の外側。
  */
 // === AUTO-GENERATED IMPORTS ===
 import { InitJobInfo } from './foot-bridge.js';
@@ -85,6 +84,7 @@ import {
     set_n_A_WeaponType, set_n_A_WeaponZokusei, set_n_A_Weapon_ATK, set_n_A_Weapon_ATKplus,
     set_n_A_Weapon_Transcendence
 } from './roro-state.js';
+import { createEmptyModel } from './calc-model.js';
 
 // ---- eval() 撤去用シム（リファクタリング計画 Phase 3） ----
 // eval("") は undefined を返すが Number("") は 0 になる等、eval と素朴な数値変換は
@@ -102,496 +102,597 @@ function legacyNum(raw) {
 }
 
 /**
- * HTMLから装備アイテムの状態を読み取ってグローバル変数を更新する
+ * document.calcForm 等の DOM から、モデル境界に含まれる値だけを読み取る（書き込みはしない）。
+ * モデルに何が含まれ何が含まれないかは calc-model.js のコメントを参照。
+ * @returns {object} createEmptyModel() の形をした、DOMから読み取った値で埋まったモデル
  */
-export function UpdateEquipItemDataByHtml() {
-
-	var charaDataManager = null;
-
-	// ＨＴＭＬの入力値を元に、変数を更新する
-	var calcForm = document.calcForm;
-
-	set_n_A_WeaponType(legacyNum(calcForm.A_WeaponType.value));
-	set_n_A_WeaponZokusei(legacyNum(calcForm.A_Weapon_zokusei.value));
-	set_n_A_Arrow(parseInt(HtmlGetObjectValueById("OBJID_SELECT_ARROW", ARROW_ID_NONE)));
-
-	// 装備部位配列初期化
-	for (var idx = 0; idx < EQUIP_REGION_ID_COUNT; idx++) {
-		n_A_Equip[idx] = 0;
-	}
-
-	n_A_Equip[EQUIP_REGION_ID_ARMS] = HtmlGetObjectValueByIdAsInteger("OBJID_ARMS_RIGHT", 0);
-	if (n_Nitou) {
-		n_A_Equip[EQUIP_REGION_ID_ARMS_LEFT] = HtmlGetObjectValueByIdAsInteger("OBJID_ARMS_LEFT", 0);
-	}
-
-	n_A_Equip[EQUIP_REGION_ID_HEAD_TOP]		 = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_TOP", 0);
-	n_A_Equip[EQUIP_REGION_ID_HEAD_MID]		 = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_MID", 0);
-	n_A_Equip[EQUIP_REGION_ID_HEAD_UNDER]	 = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_UNDER", 0);
-	n_A_Equip[EQUIP_REGION_ID_SHIELD]		 = HtmlGetObjectValueByIdAsInteger("OBJID_SHIELD", 0);
-	n_A_Equip[EQUIP_REGION_ID_BODY]			 = HtmlGetObjectValueByIdAsInteger("OBJID_BODY", 0);
-	n_A_Equip[EQUIP_REGION_ID_SHOULDER]		 = HtmlGetObjectValueByIdAsInteger("OBJID_SHOULDER", 0);
-	n_A_Equip[EQUIP_REGION_ID_SHOES]		 = HtmlGetObjectValueByIdAsInteger("OBJID_SHOES", 0);
-	n_A_Equip[EQUIP_REGION_ID_ACCESSORY_1]	 = HtmlGetObjectValueByIdAsInteger("OBJID_ACCESSORY_1", 0);
-	n_A_Equip[EQUIP_REGION_ID_ACCESSORY_2]	 = HtmlGetObjectValueByIdAsInteger("OBJID_ACCESSORY_2", 0);
-	n_A_Equip[EQUIP_REGION_ID_COSTUME_HEAD_UNDER] = HtmlGetObjectValueByIdAsInteger("A_isyou3", 0);
-
-	// 各種精錬値
-	set_n_A_HEAD_DEF_PLUS(legacyNum(calcForm.A_HEAD_DEF_PLUS.value));
-	set_n_A_BODY_DEF_PLUS(legacyNum(calcForm.A_BODY_DEF_PLUS.value));
-	set_n_A_SHIELD_DEF_PLUS(legacyNum(calcForm.A_SHIELD_DEF_PLUS.value));
-	set_n_A_SHOULDER_DEF_PLUS(legacyNum(calcForm.A_SHOULDER_DEF_PLUS.value));
-	set_n_A_SHOES_DEF_PLUS(legacyNum(calcForm.A_SHOES_DEF_PLUS.value));
-
-
-	// シャドウ装備データ
-	set_g_itemIdArray([]);
-	set_g_refinedArray([]);
-	// ルート要素の取得
-	if ((typeof g_shadowEquipController) !== "undefined") {
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_ARMS_RIGHT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_ARMS_LEFT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_BODY] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_BODY);
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_FOOT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_FOOT);
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_1] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
-		g_itemIdArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_2] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
-
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_ARMS_RIGHT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_ARMS_LEFT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_BODY] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_BODY);
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_FOOT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_FOOT);
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_1] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
-		g_refinedArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_2] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
-
-		const funcSetRndOptTable = (eqpRgnIdF, eqpRgnNameF) => {
-			const rndOptInfoArrayF = g_shadowEquipController.getRndOptInfoArray(eqpRgnNameF);
-			for (let idxF = 0; idxF < rndOptInfoArrayF.length; idxF++) {
-				SetEquipRndOptTable(eqpRgnIdF, idxF, rndOptInfoArrayF[idxF][0], rndOptInfoArrayF[idxF][1]);
-			}
-		};
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ARMS_RIGHT, CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ARMS_LEFT, CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_BODY, CShadowEquipController.EQPRGN_NAME_BODY);
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_FOOT, CShadowEquipController.EQPRGN_NAME_FOOT);
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ACCESSORY_1, CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
-		funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ACCESSORY_2, CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
-	}
-
-
-}
-
-/**
- * 装備しているカード・エンチャントの情報をグローバル変数に格納する.
- */
-export function UpdateEquipCardDataByHtml() {
-	var idxSlot = 0;
-	var itemId = 0;
-	var wpnLv = 0;
-
-	// 装着カード配列の初期化
-	for (var cardIdx = 0; cardIdx < CARD_REGION_ID_COUNT; cardIdx++) {
-		n_A_card[cardIdx] = 0;
-	}
-
-	// 右手武器
-	n_A_card[CARD_REGION_ID_ARMS_RIGHT_1] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_ARMS_RIGHT_2] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ARMS_RIGHT_3] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ARMS_RIGHT_4] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_4", 0);
-
-	// 左手武器
-	if (n_Nitou) {
-		n_A_card[CARD_REGION_ID_ARMS_LEFT_1] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_1", 0);
-		n_A_card[CARD_REGION_ID_ARMS_LEFT_2] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_2", 0);
-		n_A_card[CARD_REGION_ID_ARMS_LEFT_3] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_3", 0);
-		n_A_card[CARD_REGION_ID_ARMS_LEFT_4] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_4", 0);
-	}
-
-	// 各装着部位
-	n_A_card[CARD_REGION_ID_HEAD_TOP]	 = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_HEAD_MID]	 = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_HEAD_UNDER]	 = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_SHIELD]		 = GetStatefullData("DATA_OBJID_SHIELD_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_BODY]		 = GetStatefullData("DATA_OBJID_BODY_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_SHOULDER]	 = GetStatefullData("DATA_OBJID_SHOULDER_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_SHOES]		 = GetStatefullData("DATA_OBJID_SHOES_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_ACCESSORY_1] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_1", 0);
-	n_A_card[CARD_REGION_ID_ACCESSORY_2] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_1", 0);
-
-	// 頭上段エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_TOP_1] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_TOP_2] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_TOP_3] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_4", 0);
-
-	// 頭中段エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_MID_1] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_MID_2] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_MID_3] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_4", 0);
-
-	// 頭下段エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_1] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_2] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_3] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_4", 0);
-
-	// 盾エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_SHIELD_1] = GetStatefullData("DATA_OBJID_SHIELD_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHIELD_2] = GetStatefullData("DATA_OBJID_SHIELD_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHIELD_3] = GetStatefullData("DATA_OBJID_SHIELD_CARD_4", 0);
-
-	// 鎧エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_BODY_1] = GetStatefullData("DATA_OBJID_BODY_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_BODY_2] = GetStatefullData("DATA_OBJID_BODY_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_BODY_3] = GetStatefullData("DATA_OBJID_BODY_CARD_4", 0);
-
-	// 肩エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOULDER_1] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOULDER_2] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOULDER_3] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_4", 0);
-
-	// 靴エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOES_1] = GetStatefullData("DATA_OBJID_SHOES_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOES_2] = GetStatefullData("DATA_OBJID_SHOES_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_SHOES_3] = GetStatefullData("DATA_OBJID_SHOES_CARD_4", 0);
-
-	// アクセ１エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_1] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_2] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_3] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_4", 0);
-
-	// アクセ２エンチャント
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_1] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_2] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_3] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_4", 0);
-
-	// シャドウ装備エンチャント
-	n_A_card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_1] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_2] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_3] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_4", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_SHIELD_1] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_SHIELD_2] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_SHIELD_3] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_4", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_1] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_2] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_3] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_4", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_1] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_2] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_3] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_4", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_1] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_2] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_3] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_4", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_1] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_2", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_2] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_3", 0);
-	n_A_card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_3] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_4", 0);
-
-}
-
-export function UpdateEquipCostumeDataByHtml() {
-
-	var itemId = 0;
-	var wpnLv = 0;
-
-
-	// 装着カード配列の初期化
-	for (var costumeIdx = 0; costumeIdx < COSTUME_REGION_ID_COUNT; costumeIdx++) {
-		n_A_costume[costumeIdx] = 0;
-	}
-
-	// 各装着部位
-	n_A_costume[COSTUME_REGION_ID_HEAD_UNDER]	 = GetStatefullData("DATA_OBJID_HEAD_UNDER_COSTUME", 0);
-}
-
-/**
- * StAllCalc の DOM 走査プロローグ本体。DOM（document.calcForm・GetStatefullData 経由の
- * 隠しdiv等）を読み、その結果をモジュールグローバル（roro-state.js / ro4-state.js 等の
- * export let）へ書き込む。StAllCalcCore() 側でも必要な n_A_SpeedPOT と
- * attackMethodConfArray のみ戻り値として返す。
- */
-export function HydrateFromDom() {
-    let attackMethodConf = null;
-    let attackMethodConfArray = null;
-    let n_A_SpeedPOT = 0;
-
+export function ExtractModelFromDom() {
+    const model = createEmptyModel();
     const calcForm = document.calcForm;
 
-		InitJobInfo();
+    //----------------------------------------------------------------
+    // 基本パラメタ
+    //----------------------------------------------------------------
+    model.status.baseLv = legacyNum(calcForm.A_BaseLV.value);
+    model.status.jobLv = legacyNum(calcForm.A_JobLV.value);
+    model.status.str = legacyNum(calcForm.A_STR.value);
+    model.status.agi = legacyNum(calcForm.A_AGI.value);
+    model.status.vit = legacyNum(calcForm.A_VIT.value);
+    model.status.dex = legacyNum(calcForm.A_DEX.value);
+    model.status.int = legacyNum(calcForm.A_INT.value);
+    model.status.luk = legacyNum(calcForm.A_LUK.value);
+    model.status.speedPot = legacyNum(calcForm.A_SpeedPOT.value);
 
-		//----------------------------------------------------------------
-		// 基本パラメタを取得する
-		//----------------------------------------------------------------
+    //----------------------------------------------------------------
+    // 装備（本体アイテムID・矢・武器種別属性・各種精錬値）
+    //----------------------------------------------------------------
+    model.weapon.type = legacyNum(calcForm.A_WeaponType.value);
+    model.weapon.zokusei = legacyNum(calcForm.A_Weapon_zokusei.value);
+    model.arrow = HtmlGetObjectValueById("OBJID_SELECT_ARROW", ARROW_ID_NONE);
 
-		set_n_A_BaseLV(legacyNum(calcForm.A_BaseLV.value));
-		set_n_A_JobLV(legacyNum(calcForm.A_JobLV.value));
+    model.equip = new Array(EQUIP_REGION_ID_COUNT).fill(0);
+    model.equip[EQUIP_REGION_ID_ARMS] = HtmlGetObjectValueByIdAsInteger("OBJID_ARMS_RIGHT", 0);
+    if (n_Nitou) {
+        model.equip[EQUIP_REGION_ID_ARMS_LEFT] = HtmlGetObjectValueByIdAsInteger("OBJID_ARMS_LEFT", 0);
+    }
+    model.equip[EQUIP_REGION_ID_HEAD_TOP] = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_TOP", 0);
+    model.equip[EQUIP_REGION_ID_HEAD_MID] = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_MID", 0);
+    model.equip[EQUIP_REGION_ID_HEAD_UNDER] = HtmlGetObjectValueByIdAsInteger("OBJID_HEAD_UNDER", 0);
+    model.equip[EQUIP_REGION_ID_SHIELD] = HtmlGetObjectValueByIdAsInteger("OBJID_SHIELD", 0);
+    model.equip[EQUIP_REGION_ID_BODY] = HtmlGetObjectValueByIdAsInteger("OBJID_BODY", 0);
+    model.equip[EQUIP_REGION_ID_SHOULDER] = HtmlGetObjectValueByIdAsInteger("OBJID_SHOULDER", 0);
+    model.equip[EQUIP_REGION_ID_SHOES] = HtmlGetObjectValueByIdAsInteger("OBJID_SHOES", 0);
+    model.equip[EQUIP_REGION_ID_ACCESSORY_1] = HtmlGetObjectValueByIdAsInteger("OBJID_ACCESSORY_1", 0);
+    model.equip[EQUIP_REGION_ID_ACCESSORY_2] = HtmlGetObjectValueByIdAsInteger("OBJID_ACCESSORY_2", 0);
+    model.equip[EQUIP_REGION_ID_COSTUME_HEAD_UNDER] = HtmlGetObjectValueByIdAsInteger("A_isyou3", 0);
 
-		set_n_A_STR(legacyNum(calcForm.A_STR.value));
-		set_n_A_AGI(legacyNum(calcForm.A_AGI.value));
-		set_n_A_VIT(legacyNum(calcForm.A_VIT.value));
-		set_n_A_DEX(legacyNum(calcForm.A_DEX.value));
-		set_n_A_INT(legacyNum(calcForm.A_INT.value));
-		set_n_A_LUK(legacyNum(calcForm.A_LUK.value));
+    model.defPlus.head = legacyNum(calcForm.A_HEAD_DEF_PLUS.value);
+    model.defPlus.body = legacyNum(calcForm.A_BODY_DEF_PLUS.value);
+    model.defPlus.shield = legacyNum(calcForm.A_SHIELD_DEF_PLUS.value);
+    model.defPlus.shoulder = legacyNum(calcForm.A_SHOULDER_DEF_PLUS.value);
+    model.defPlus.shoes = legacyNum(calcForm.A_SHOES_DEF_PLUS.value);
 
-		set_SU_STR(n_A_STR);
-		set_SU_AGI(n_A_AGI);
-		set_SU_VIT(n_A_VIT);
-		set_SU_DEX(n_A_DEX);
-		set_SU_INT(n_A_INT);
-		set_SU_LUK(n_A_LUK);
+    model.weapon.transcendence = legacyNum(calcForm.A_Weapon_Transcendence.value);
+    model.weapon.weapon2Transcendence = legacyNum(calcForm.A_Weapon2_Transcendence.value);
+    model.defTranscendence.head = legacyNum(calcForm.A_HEAD_DEF_Transcendence.value);
+    model.defTranscendence.shield = legacyNum(calcForm.A_SHIELD_DEF_Transcendence.value);
+    model.defTranscendence.body = legacyNum(calcForm.A_BODY_DEF_Transcendence.value);
+    model.defTranscendence.shoulder = legacyNum(calcForm.A_SHOULDER_DEF_Transcendence.value);
+    model.defTranscendence.shoes = legacyNum(calcForm.A_SHOES_DEF_Transcendence.value);
 
+    model.weapon.atkPlus = legacyNum(calcForm.A_Weapon_ATKplus.value);
+    if (n_Nitou) {
+        model.weapon.weapon2AtkPlus = legacyNum(calcForm.A_Weapon2_ATKplus.value);
+    }
 
-		n_A_SpeedPOT = legacyNum(calcForm.A_SpeedPOT.value);
+    //----------------------------------------------------------------
+    // 装着カード・エンチャント（CARD_REGION_ID_* で添字アクセス）
+    //----------------------------------------------------------------
+    model.card = new Array(CARD_REGION_ID_COUNT).fill(0);
 
+    model.card[CARD_REGION_ID_ARMS_RIGHT_1] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_1", 0);
+    model.card[CARD_REGION_ID_ARMS_RIGHT_2] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_2", 0);
+    model.card[CARD_REGION_ID_ARMS_RIGHT_3] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_3", 0);
+    model.card[CARD_REGION_ID_ARMS_RIGHT_4] = GetStatefullData("DATA_OBJID_ARMS_RIGHT_CARD_4", 0);
 
-		//----------------------------------------------------------------
-		// 特性パラメタを取得する
-		//----------------------------------------------------------------
+    if (n_Nitou) {
+        model.card[CARD_REGION_ID_ARMS_LEFT_1] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_1", 0);
+        model.card[CARD_REGION_ID_ARMS_LEFT_2] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_2", 0);
+        model.card[CARD_REGION_ID_ARMS_LEFT_3] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_3", 0);
+        model.card[CARD_REGION_ID_ARMS_LEFT_4] = GetStatefullData("DATA_OBJID_ARMS_LEFT_CARD_4", 0);
+    }
 
-		// 合計値
-		set_n_A_STA(GetTotalSpecStatus(MIG_PARAM_ID_STA));
-		set_n_A_WIS(GetTotalSpecStatus(MIG_PARAM_ID_WIS));
-		set_n_A_SPL(GetTotalSpecStatus(MIG_PARAM_ID_SPL));
-		set_n_A_CRT(GetTotalSpecStatus(MIG_PARAM_ID_CRT));
+    model.card[CARD_REGION_ID_HEAD_TOP] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_1", 0);
+    model.card[CARD_REGION_ID_HEAD_MID] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_1", 0);
+    model.card[CARD_REGION_ID_HEAD_UNDER] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_1", 0);
+    model.card[CARD_REGION_ID_SHIELD] = GetStatefullData("DATA_OBJID_SHIELD_CARD_1", 0);
+    model.card[CARD_REGION_ID_BODY] = GetStatefullData("DATA_OBJID_BODY_CARD_1", 0);
+    model.card[CARD_REGION_ID_SHOULDER] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_1", 0);
+    model.card[CARD_REGION_ID_SHOES] = GetStatefullData("DATA_OBJID_SHOES_CARD_1", 0);
+    model.card[CARD_REGION_ID_ACCESSORY_1] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_1", 0);
+    model.card[CARD_REGION_ID_ACCESSORY_2] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_1", 0);
 
-		//----------------------------------------------------------------
-		// 装備を取得する
-		//----------------------------------------------------------------
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_TOP_1] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_TOP_2] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_TOP_3] = GetStatefullData("DATA_OBJID_HEAD_TOP_CARD_4", 0);
 
-		UpdateEquipItemDataByHtml();
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_MID_1] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_MID_2] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_MID_3] = GetStatefullData("DATA_OBJID_HEAD_MID_CARD_4", 0);
 
-		// 超越段階
-		set_n_A_Weapon_Transcendence(legacyNum(calcForm.A_Weapon_Transcendence.value));
-		set_n_A_Weapon2_Transcendence(legacyNum(calcForm.A_Weapon2_Transcendence.value));
-		set_n_A_HEAD_DEF_Transcendence(legacyNum(calcForm.A_HEAD_DEF_Transcendence.value));
-		set_n_A_SHIELD_DEF_Transcendence(legacyNum(calcForm.A_SHIELD_DEF_Transcendence.value));
-		set_n_A_BODY_DEF_Transcendence(legacyNum(calcForm.A_BODY_DEF_Transcendence.value));
-		set_n_A_SHOULDER_DEF_Transcendence(legacyNum(calcForm.A_SHOULDER_DEF_Transcendence.value));
-		set_n_A_SHOES_DEF_Transcendence(legacyNum(calcForm.A_SHOES_DEF_Transcendence.value));
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_1] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_2] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_HEAD_UNDER_3] = GetStatefullData("DATA_OBJID_HEAD_UNDER_CARD_4", 0);
 
-		//----------------------------------------------------------------
-		// 攻撃手段を取得する
-		//----------------------------------------------------------------
-		attackMethodConf = CAttackMethodAreaComponentManager.GetAttackMethodConf();
+    model.card[CARD_REGION_ID_ENCHANT_SHIELD_1] = GetStatefullData("DATA_OBJID_SHIELD_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHIELD_2] = GetStatefullData("DATA_OBJID_SHIELD_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHIELD_3] = GetStatefullData("DATA_OBJID_SHIELD_CARD_4", 0);
 
-		set_n_A_ActiveSkill(attackMethodConf.GetSkillId());
-		set_n_A_ActiveSkillLV(attackMethodConf.GetSkillLv());
+    model.card[CARD_REGION_ID_ENCHANT_BODY_1] = GetStatefullData("DATA_OBJID_BODY_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_BODY_2] = GetStatefullData("DATA_OBJID_BODY_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_BODY_3] = GetStatefullData("DATA_OBJID_BODY_CARD_4", 0);
 
-		attackMethodConfArray = [attackMethodConf];
+    model.card[CARD_REGION_ID_ENCHANT_SHOULDER_1] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHOULDER_2] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHOULDER_3] = GetStatefullData("DATA_OBJID_SHOULDER_CARD_4", 0);
 
-		set_n_A_WeaponLV(Math.floor(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS]][ITEM_DATA_INDEX_WPNLV] % 10));
+    model.card[CARD_REGION_ID_ENCHANT_SHOES_1] = GetStatefullData("DATA_OBJID_SHOES_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHOES_2] = GetStatefullData("DATA_OBJID_SHOES_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_SHOES_3] = GetStatefullData("DATA_OBJID_SHOES_CARD_4", 0);
 
-		// 従来の処理
-		set_n_A_Weapon_ATK(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS]][ITEM_DATA_INDEX_POWER]);
-		
-		set_n_A_Weapon_ATKplus(legacyNum(calcForm.A_Weapon_ATKplus.value));
-		set_n_A_WeaponLV_seirenATK(0);
-		set_n_A_WeaponLV_Minplus(0);
-		set_n_A_WeaponLV_Maxplus(0);
-		if(n_A_WeaponLV == 1){
-			set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 2);
-			if(n_A_Weapon_ATKplus >= 8){
-				set_n_A_WeaponLV_Minplus(1);
-				set_n_A_WeaponLV_Maxplus(3 * (n_A_Weapon_ATKplus - 7));
-			}
-		}else if(n_A_WeaponLV == 2){
-			set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 3);
-			if(n_A_Weapon_ATKplus >= 7){
-				set_n_A_WeaponLV_Minplus(1);
-				set_n_A_WeaponLV_Maxplus(5 * (n_A_Weapon_ATKplus - 6));
-			}
-		}else if(n_A_WeaponLV == 3){
-			set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 5);
-			if(n_A_Weapon_ATKplus >= 6){
-				set_n_A_WeaponLV_Minplus(1);
-				set_n_A_WeaponLV_Maxplus(8 * (n_A_Weapon_ATKplus - 5));
-			}
-		}else if(n_A_WeaponLV == 4){
-			set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 7);
-			if(n_A_Weapon_ATKplus >= 5){
-				set_n_A_WeaponLV_Minplus(1);
-				set_n_A_WeaponLV_Maxplus(14 * (n_A_Weapon_ATKplus - 4));
-			}
-		}
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_1] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_2] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_1_3] = GetStatefullData("DATA_OBJID_ACCESSORY_1_CARD_4", 0);
 
-		set_n_A_Weapon2_ATKplus(0);
-		if (n_Nitou) {
-			set_n_A_Weapon2LV(Math.floor(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS_LEFT]][ITEM_DATA_INDEX_WPNLV] % 10));
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_1] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_2", 0);
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_2] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_3", 0);
+    model.card[CARD_REGION_ID_ENCHANT_ACCESSORY_2_3] = GetStatefullData("DATA_OBJID_ACCESSORY_2_CARD_4", 0);
 
-			set_n_A_Weapon2_ATK(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS_LEFT]][ITEM_DATA_INDEX_POWER]);
+    model.card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_1] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_2] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_ARMS_RIGHT_3] = GetStatefullData("DATA_OBJID_SHADOW_ARMS_RIGHT_CARD_4", 0);
+    model.card[CARD_REGION_ID_SHADOW_SHIELD_1] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_SHIELD_2] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_SHIELD_3] = GetStatefullData("DATA_OBJID_SHADOW_SHIELD_CARD_4", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_1] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_2] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_BODY_3] = GetStatefullData("DATA_OBJID_SHADOW_BODY_CARD_4", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_1] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_2] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_SHOES_3] = GetStatefullData("DATA_OBJID_SHADOW_SHOES_CARD_4", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_1] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_2] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY1_3] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-1_CARD_4", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_1] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_2", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_2] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_3", 0);
+    model.card[CARD_REGION_ID_SHADOW_ENCHANT_ACCESSORY2_3] = GetStatefullData("DATA_OBJID_SHADOW_ACCESSORY-2_CARD_4", 0);
 
-			set_n_A_Weapon2_ATKplus(legacyNum(document.calcForm.A_Weapon2_ATKplus.value));
-			set_n_A_Weapon2LV_seirenATK(0);
-			set_n_A_Weapon2LV_Minplus(0);
-			set_n_A_Weapon2LV_Maxplus(0);
-			if(n_A_Weapon2LV == 1){
-				set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 2);
-				if(n_A_Weapon2_ATKplus >= 8){
-					set_n_A_Weapon2LV_Minplus(1);
-					set_n_A_Weapon2LV_Maxplus(3 * (n_A_Weapon2_ATKplus - 7));
-				}
-			}else if(n_A_Weapon2LV == 2){
-				set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 3);
-				if(n_A_Weapon2_ATKplus >= 7){
-					set_n_A_Weapon2LV_Minplus(1);
-					set_n_A_Weapon2LV_Maxplus(5 * (n_A_Weapon2_ATKplus - 6));
-				}
-			}else if(n_A_Weapon2LV == 3){
-				set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 5);
-				if(n_A_Weapon2_ATKplus >= 6){
-					set_n_A_Weapon2LV_Minplus(1);
-					set_n_A_Weapon2LV_Maxplus(8 * (n_A_Weapon2_ATKplus - 5));
-				}
-			}else if(n_A_Weapon2LV == 4){
-				set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 7);
-				if(n_A_Weapon2_ATKplus >= 5){
-					set_n_A_Weapon2LV_Minplus(1);
-					set_n_A_Weapon2LV_Maxplus(14 * (n_A_Weapon2_ATKplus - 4));
-				}
-			}
-		}
+    //----------------------------------------------------------------
+    // 装着衣装
+    //----------------------------------------------------------------
+    model.costume = new Array(COSTUME_REGION_ID_COUNT).fill(0);
+    model.costume[COSTUME_REGION_ID_HEAD_UNDER] = GetStatefullData("DATA_OBJID_HEAD_UNDER_COSTUME", 0);
 
+    //----------------------------------------------------------------
+    // 職業スキル（パッシブ/持続系。A1欄）
+    //----------------------------------------------------------------
+    if (n_Skill1SW) {
+        const passiveSkillIdArray = g_constDataManager.GetDataObject(CONST_DATA_KIND_JOB, n_A_JOB).GetPassiveSkillIdArray();
+        // 要素が存在しない項目は null のままにする（legacyNum が undefined を返すケースと
+        // 区別するため。「未抽出」は null、「抽出したが値が空文字」は undefined で表す）。
+        model.passiveSkill = new Array(passiveSkillIdArray.length).fill(null);
+        for (let i = 0; i < passiveSkillIdArray.length; i++) {
+            const wOBJ = document.getElementById("A_skill" + i);
+            if (wOBJ !== null) {
+                model.passiveSkill[i] = legacyNum(wOBJ.value);
+            }
+        }
+    }
 
-		//----------------------------------------------------------------
-		// 装着カードを取得する
-		//----------------------------------------------------------------
+    //----------------------------------------------------------------
+    // ギルドスキル/ゴスペル/他（A4欄）
+    //----------------------------------------------------------------
+    if (n_Skill4SW) {
+        model.buff4[0] = calcForm.A4_Skill0.checked;
+        model.buff4[1] = legacyNum(calcForm.A4_Skill1.value);
+        model.buff4[2] = legacyNum(calcForm.A4_Skill2.value);
+        model.buff4[3] = legacyNum(calcForm.A4_Skill3.value);
+        model.buff4[4] = legacyNum(calcForm.A4_Skill4.value);
+        model.buff4[5] = calcForm.A4_Skill5.checked;
+        model.buff4[6] = calcForm.A4_Skill6.checked;
+        model.buff4[7] = calcForm.A4_Skill7.checked;
+        model.buff4[8] = calcForm.A4_Skill8.checked;
+        model.buff4[9] = calcForm.A4_Skill9.checked;
+        model.buff4[10] = calcForm.A4_Skill10.checked;
+        model.buff4[11] = legacyNum(calcForm.A4_Skill11.value);
+        model.buff4[30] = legacyNum(calcForm.A4_Skill30.value);
+        model.buff4[31] = legacyNum(calcForm.A4_Skill31.value);
+        model.buff4[32] = legacyNum(calcForm.A4_Skill32.value);
+        model.buff4[33] = legacyNum(calcForm.A4_Skill33.value);
+        model.buff4[34] = legacyNum(calcForm.A4_Skill34.value);
+        model.buff4[35] = legacyNum(calcForm.A4_Skill35.value);
+    }
 
-		UpdateEquipCardDataByHtml();
+    //----------------------------------------------------------------
+    // オートスペル設定
+    //----------------------------------------------------------------
+    // 要素が存在しない項目は null のままにする（legacyNum が undefined を返すケースと
+    // 区別するため。「未抽出」は null、「抽出したが値が空文字」は undefined で表す）。
+    model.autoSpell = [];
+    for (let idx = 0; idx < AUTO_SPELL_SETTING_COUNT; idx++) {
+        let objSelect = document.getElementById("OBJID_AS_SKILL_ID_" + (OBJID_OFFSET_AS_SKILL_ID + idx));
+        model.autoSpell[OBJID_OFFSET_AS_SKILL_ID + idx] = null;
+        if (objSelect) {
+            model.autoSpell[OBJID_OFFSET_AS_SKILL_ID + idx] = legacyNum(objSelect.value);
+        }
 
+        objSelect = document.getElementById("OBJID_AS_SKILL_LV_" + (OBJID_OFFSET_AS_SKILL_LV + idx));
+        model.autoSpell[OBJID_OFFSET_AS_SKILL_LV + idx] = null;
+        if (objSelect) {
+            model.autoSpell[OBJID_OFFSET_AS_SKILL_LV + idx] = legacyNum(objSelect.value);
+        }
 
-		//----------------------------------------------------------------
-		// 装着衣装を取得する
-		//----------------------------------------------------------------
+        objSelect = document.getElementById("OBJID_AS_SKILL_PROB_" + (OBJID_OFFSET_AS_SKILL_PROB + idx));
+        model.autoSpell[OBJID_OFFSET_AS_SKILL_PROB + idx] = null;
+        if (objSelect) {
+            model.autoSpell[OBJID_OFFSET_AS_SKILL_PROB + idx] = legacyNum(objSelect.value);
+        }
+    }
 
-		UpdateEquipCostumeDataByHtml();
+    //----------------------------------------------------------------
+    // アイテム(食品/他)（A7欄）
+    //----------------------------------------------------------------
+    if (n_Skill7SW) {
+        model.buff7[0] = calcForm.A7_Skill0.checked;
+        model.buff7[1] = calcForm.A7_Skill1.checked;
+        model.buff7[2] = calcForm.A7_Skill2.checked;
+        model.buff7[3] = legacyNum(calcForm.A7_Skill3.value);
+        model.buff7[4] = legacyNum(calcForm.A7_Skill4.value);
+        model.buff7[5] = legacyNum(calcForm.A7_Skill5.value);
+        model.buff7[6] = legacyNum(calcForm.A7_Skill6.value);
+        model.buff7[7] = legacyNum(calcForm.A7_Skill7.value);
+        model.buff7[8] = legacyNum(calcForm.A7_Skill8.value);
+        model.buff7[9] = calcForm.A7_Skill9.checked;
+        model.buff7[10] = calcForm.A7_Skill10.checked;
+        model.buff7[11] = calcForm.A7_Skill11.checked;
+        model.buff7[12] = calcForm.A7_Skill12.checked;
+        model.buff7[13] = calcForm.A7_Skill13.checked;
+        model.buff7[14] = calcForm.A7_Skill14.checked;
+        model.buff7[15] = calcForm.A7_Skill15.checked;
+        model.buff7[16] = calcForm.A7_Skill16.checked;
+        model.buff7[17] = calcForm.A7_Skill17.checked;
+        model.buff7[18] = calcForm.A7_Skill18.checked;
+        model.buff7[19] = calcForm.A7_Skill19.checked;
+        model.buff7[20] = calcForm.A7_Skill20.checked;
+        model.buff7[21] = calcForm.A7_Skill21.checked;
+        model.buff7[22] = calcForm.A7_Skill22.checked;
+        model.buff7[23] = calcForm.A7_Skill23.checked;
+        model.buff7[24] = calcForm.A7_Skill24.checked;
+        model.buff7[25] = calcForm.A7_Skill25.checked;
+        model.buff7[26] = calcForm.A7_Skill26.checked;
+        model.buff7[27] = calcForm.A7_Skill27.checked;
+        model.buff7[28] = calcForm.A7_Skill28.checked;
+        model.buff7[29] = calcForm.A7_Skill29.checked;
+        model.buff7[30] = calcForm.A7_Skill30.checked;
+        model.buff7[31] = calcForm.A7_Skill31.checked;
+        model.buff7[32] = calcForm.A7_Skill32.checked;
+        model.buff7[33] = calcForm.A7_Skill33.checked;
+        model.buff7[34] = calcForm.A7_Skill34.checked;
+        model.buff7[35] = calcForm.A7_Skill35.checked;
+        model.buff7[36] = calcForm.A7_Skill36.checked;
+        model.buff7[37] = calcForm.A7_Skill37.checked;
+        model.buff7[38] = legacyNum(calcForm.A7_Skill38.value);
+        model.buff7[39] = legacyNum(calcForm.A7_Skill39.value);
+        model.buff7[40] = calcForm.A7_Skill40.checked;
+        model.buff7[41] = legacyNum(calcForm.A7_Skill41.value);
+        model.buff7[42] = legacyNum(calcForm.A7_Skill42.value);
+        model.buff7[43] = legacyNum(calcForm.A7_Skill43.value);
+        model.buff7[44] = legacyNum(calcForm.A7_Skill44.value);
+        model.buff7[45] = legacyNum(calcForm.A7_Skill45.value);
+        model.buff7[46] = legacyNum(calcForm.A7_Skill46.value);
+        model.buff7[47] = legacyNum(calcForm.A7_Skill47.value);
+        model.buff7[48] = calcForm.A7_Skill48.checked;
+        model.buff7[49] = calcForm.A7_Skill49.checked;
+        model.buff7[50] = legacyNum(calcForm.A7_Skill50.value);
+        model.buff7[51] = calcForm.A7_Skill51.checked;
+        model.buff7[52] = legacyNum(calcForm.A7_Skill52.value);
+    }
 
+    //----------------------------------------------------------------
+    // その他の支援/設定（A8欄）
+    //----------------------------------------------------------------
+    if (n_Skill8SW) {
+        model.buff8[0] = legacyNum(calcForm.A8_Skill0.value);
+        model.buff8[1] = legacyNum(calcForm.A8_Skill1.value);
+        model.buff8[2] = legacyNum(calcForm.A8_Skill2.value);
+        model.buff8[3] = legacyNum(calcForm.A8_Skill3.value);
+        model.buff8[4] = calcForm.A8_Skill4.checked;
+        model.buff8[5] = legacyNum(calcForm.A8_Skill5.value);
+        model.buff8[6] = legacyNum(calcForm.A8_Skill6.value);
+        model.buff8[7] = legacyNum(calcForm.A8_Skill7.value);
+        model.buff8[12] = legacyNum(calcForm.A8_Skill12.value);
+        model.buff8[13] = calcForm.A8_Skill13.checked;
+        model.buff8[15] = legacyNum(calcForm.A8_Skill15.value);
+        model.buff8[16] = calcForm.A8_Skill16.checked;
+        model.buff8[17] = legacyNum(calcForm.A8_Skill17.value);
+        model.buff8[19] = calcForm.A8_Skill19.checked;
+        model.buff8[21] = legacyNum(calcForm.A8_Skill21.value);
+        model.buff8[22] = legacyNum(calcForm.A8_Skill22.value);
+    }
 
-		var passiveSkillIdArray = g_constDataManager.GetDataObject(CONST_DATA_KIND_JOB, n_A_JOB).GetPassiveSkillIdArray();
+    return model;
+}
 
-		if(n_Skill1SW){
-			for(let i = 0; i < passiveSkillIdArray.length; i++){
-				let wOBJ = document.getElementById("A_skill"+i);
-				if (wOBJ !== null) {
-					n_A_PassSkill[i] = legacyNum(wOBJ.value);
-				}
-			}
-		}
+/**
+ * モデルからモジュールグローバル（roro-state.js / ro4-state.js 等の export let）へ書き込む。
+ * DOM は一切読まない（境界の外側の依存 — 職業選択・攻撃手段・シャドウ装備コンポーネント・
+ * 性能カスタマイズ合計値 — は例外で、既存のグローバル/コンポーネントを直接読む。
+ * calc-model.js 先頭のコメント参照）。
+ * StAllCalcCore() 側でも必要な attackMethodConfArray のみ戻り値として返す
+ * （n_A_SpeedPOT はモデル自身に model.status.speedPot として残るため、呼び出し元が
+ * モデルから直接読める）。
+ * @param {object} model createEmptyModel() の形をしたモデル
+ * @returns {{attackMethodConfArray: object[]}}
+ */
+export function HydrateFromModel(model) {
+    InitJobInfo();
 
-		if(n_Skill4SW){
-			n_A_PassSkill4[0] = calcForm.A4_Skill0.checked;
-			n_A_PassSkill4[1] = legacyNum(calcForm.A4_Skill1.value);
-			n_A_PassSkill4[2] = legacyNum(calcForm.A4_Skill2.value);
-			n_A_PassSkill4[3] = legacyNum(calcForm.A4_Skill3.value);
-			n_A_PassSkill4[4] = legacyNum(calcForm.A4_Skill4.value);
-			n_A_PassSkill4[5] = calcForm.A4_Skill5.checked;
-			n_A_PassSkill4[6] = calcForm.A4_Skill6.checked;
-			n_A_PassSkill4[7] = calcForm.A4_Skill7.checked;
-			n_A_PassSkill4[8] = calcForm.A4_Skill8.checked;
-			n_A_PassSkill4[9] = calcForm.A4_Skill9.checked;
-			n_A_PassSkill4[10] = calcForm.A4_Skill10.checked;
-			n_A_PassSkill4[11] = legacyNum(calcForm.A4_Skill11.value);
-			n_A_PassSkill4[30] = legacyNum(calcForm.A4_Skill30.value);
-			n_A_PassSkill4[31] = legacyNum(calcForm.A4_Skill31.value);
-			n_A_PassSkill4[32] = legacyNum(calcForm.A4_Skill32.value);
-			n_A_PassSkill4[33] = legacyNum(calcForm.A4_Skill33.value);
-			n_A_PassSkill4[34] = legacyNum(calcForm.A4_Skill34.value);
-			n_A_PassSkill4[35] = legacyNum(calcForm.A4_Skill35.value);
-		}
+    //----------------------------------------------------------------
+    // 基本パラメタを設定する
+    //----------------------------------------------------------------
 
-		// オートスペル設定の取得
-		var objSelect = null;
-		for (var idx = 0; idx < AUTO_SPELL_SETTING_COUNT; idx++) {
-			objSelect = document.getElementById("OBJID_AS_SKILL_ID_" + (OBJID_OFFSET_AS_SKILL_ID + idx));
-			if (objSelect) {
-				n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_ID + idx] = legacyNum(objSelect.value);
-			}
+    set_n_A_BaseLV(model.status.baseLv);
+    set_n_A_JobLV(model.status.jobLv);
 
-			objSelect = document.getElementById("OBJID_AS_SKILL_LV_" + (OBJID_OFFSET_AS_SKILL_LV + idx));
-			if (objSelect) {
-				n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_LV + idx] = legacyNum(objSelect.value);
-			}
+    set_n_A_STR(model.status.str);
+    set_n_A_AGI(model.status.agi);
+    set_n_A_VIT(model.status.vit);
+    set_n_A_DEX(model.status.dex);
+    set_n_A_INT(model.status.int);
+    set_n_A_LUK(model.status.luk);
 
-			objSelect = document.getElementById("OBJID_AS_SKILL_PROB_" + (OBJID_OFFSET_AS_SKILL_PROB + idx));
-			if (objSelect) {
-				n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_PROB + idx] = legacyNum(objSelect.value);
-			}
-		}
+    set_SU_STR(n_A_STR);
+    set_SU_AGI(n_A_AGI);
+    set_SU_VIT(n_A_VIT);
+    set_SU_DEX(n_A_DEX);
+    set_SU_INT(n_A_INT);
+    set_SU_LUK(n_A_LUK);
 
-		// アイテム(食品/他) の取得
-		if(n_Skill7SW){
-			n_A_PassSkill7[0] = calcForm.A7_Skill0.checked;
-			n_A_PassSkill7[1] = calcForm.A7_Skill1.checked;
-			n_A_PassSkill7[2] = calcForm.A7_Skill2.checked;
-			n_A_PassSkill7[3] = legacyNum(calcForm.A7_Skill3.value);
-			n_A_PassSkill7[4] = legacyNum(calcForm.A7_Skill4.value);
-			n_A_PassSkill7[5] = legacyNum(calcForm.A7_Skill5.value);
-			n_A_PassSkill7[6] = legacyNum(calcForm.A7_Skill6.value);
-			n_A_PassSkill7[7] = legacyNum(calcForm.A7_Skill7.value);
-			n_A_PassSkill7[8] = legacyNum(calcForm.A7_Skill8.value);
-			n_A_PassSkill7[9] = calcForm.A7_Skill9.checked;
-			n_A_PassSkill7[10] = calcForm.A7_Skill10.checked;
-			n_A_PassSkill7[11] = calcForm.A7_Skill11.checked;
-			n_A_PassSkill7[12] = calcForm.A7_Skill12.checked;
-			n_A_PassSkill7[13] = calcForm.A7_Skill13.checked;
-			n_A_PassSkill7[14] = calcForm.A7_Skill14.checked;
-			n_A_PassSkill7[15] = calcForm.A7_Skill15.checked;
-			n_A_PassSkill7[16] = calcForm.A7_Skill16.checked;
-			n_A_PassSkill7[17] = calcForm.A7_Skill17.checked;
-			n_A_PassSkill7[18] = calcForm.A7_Skill18.checked;
-			n_A_PassSkill7[19] = calcForm.A7_Skill19.checked;
-			n_A_PassSkill7[20] = calcForm.A7_Skill20.checked;
-			n_A_PassSkill7[21] = calcForm.A7_Skill21.checked;
-			n_A_PassSkill7[22] = calcForm.A7_Skill22.checked;
-			n_A_PassSkill7[23] = calcForm.A7_Skill23.checked;
-			n_A_PassSkill7[24] = calcForm.A7_Skill24.checked;
-			n_A_PassSkill7[25] = calcForm.A7_Skill25.checked;
-			n_A_PassSkill7[26] = calcForm.A7_Skill26.checked;
-			n_A_PassSkill7[27] = calcForm.A7_Skill27.checked;
-			n_A_PassSkill7[28] = calcForm.A7_Skill28.checked;
-			n_A_PassSkill7[29] = calcForm.A7_Skill29.checked;
-			n_A_PassSkill7[30] = calcForm.A7_Skill30.checked;
-			n_A_PassSkill7[31] = calcForm.A7_Skill31.checked;
-			n_A_PassSkill7[32] = calcForm.A7_Skill32.checked;
-			n_A_PassSkill7[33] = calcForm.A7_Skill33.checked;
-			n_A_PassSkill7[34] = calcForm.A7_Skill34.checked;
-			n_A_PassSkill7[35] = calcForm.A7_Skill35.checked;
-			n_A_PassSkill7[36] = calcForm.A7_Skill36.checked;
-			n_A_PassSkill7[37] = calcForm.A7_Skill37.checked;
-			n_A_PassSkill7[38] = legacyNum(calcForm.A7_Skill38.value);
-			n_A_PassSkill7[39] = legacyNum(calcForm.A7_Skill39.value);
-			n_A_PassSkill7[40] = calcForm.A7_Skill40.checked;
-			n_A_PassSkill7[41] = legacyNum(calcForm.A7_Skill41.value);
-			n_A_PassSkill7[42] = legacyNum(calcForm.A7_Skill42.value);
-			n_A_PassSkill7[43] = legacyNum(calcForm.A7_Skill43.value);
-			n_A_PassSkill7[44] = legacyNum(calcForm.A7_Skill44.value);
-			n_A_PassSkill7[45] = legacyNum(calcForm.A7_Skill45.value);
-			n_A_PassSkill7[46] = legacyNum(calcForm.A7_Skill46.value);
-			n_A_PassSkill7[47] = legacyNum(calcForm.A7_Skill47.value);
-			n_A_PassSkill7[48] = calcForm.A7_Skill48.checked;
-			n_A_PassSkill7[49] = calcForm.A7_Skill49.checked;
-			n_A_PassSkill7[50] = legacyNum(calcForm.A7_Skill50.value);
-			n_A_PassSkill7[51] = calcForm.A7_Skill51.checked;
-			n_A_PassSkill7[52] = legacyNum(calcForm.A7_Skill52.value);
-		}
-		n_A_PassSkill8[14] = 0;
-		if(n_Skill8SW){
-			n_A_PassSkill8[0] = legacyNum(calcForm.A8_Skill0.value);
-			n_A_PassSkill8[1] = legacyNum(calcForm.A8_Skill1.value);
-			n_A_PassSkill8[2] = legacyNum(calcForm.A8_Skill2.value);
-			n_A_PassSkill8[3] = legacyNum(calcForm.A8_Skill3.value);
-			n_A_PassSkill8[4] = calcForm.A8_Skill4.checked;
-			n_A_PassSkill8[5] = legacyNum(calcForm.A8_Skill5.value);
-			n_A_PassSkill8[6] = legacyNum(calcForm.A8_Skill6.value);
-			n_A_PassSkill8[7] = legacyNum(calcForm.A8_Skill7.value);
-			n_A_PassSkill8[12] = legacyNum(calcForm.A8_Skill12.value);
-			n_A_PassSkill8[13] = calcForm.A8_Skill13.checked;
-			n_A_PassSkill8[15] = legacyNum(calcForm.A8_Skill15.value);
-			n_A_PassSkill8[16] = calcForm.A8_Skill16.checked;
-			n_A_PassSkill8[17] = legacyNum(calcForm.A8_Skill17.value);
-			n_A_PassSkill8[19] = calcForm.A8_Skill19.checked;
-			n_A_PassSkill8[21] = legacyNum(calcForm.A8_Skill21.value);
-			n_A_PassSkill8[22] = legacyNum(calcForm.A8_Skill22.value);
-			if(41 <= n_A_JOB && n_A_JOB <= 43){
-				if(n_A_PassSkill8[19] == 0) document.getElementById("ID_A_HUYO_NAME").textContent = "暖かい風";
-				else document.getElementById("ID_A_HUYO_NAME").textContent = "武器属性付与";
-			}
-		}
+    //----------------------------------------------------------------
+    // 特性パラメタを設定する
+    //----------------------------------------------------------------
 
-    return { n_A_SpeedPOT, attackMethodConfArray };
+    // 合計値
+    set_n_A_STA(GetTotalSpecStatus(MIG_PARAM_ID_STA));
+    set_n_A_WIS(GetTotalSpecStatus(MIG_PARAM_ID_WIS));
+    set_n_A_SPL(GetTotalSpecStatus(MIG_PARAM_ID_SPL));
+    set_n_A_CRT(GetTotalSpecStatus(MIG_PARAM_ID_CRT));
+
+    //----------------------------------------------------------------
+    // 装備を設定する
+    //----------------------------------------------------------------
+
+    set_n_A_WeaponType(model.weapon.type);
+    set_n_A_WeaponZokusei(model.weapon.zokusei);
+    set_n_A_Arrow(parseInt(model.arrow));
+
+    for (let idx = 0; idx < EQUIP_REGION_ID_COUNT; idx++) {
+        n_A_Equip[idx] = model.equip[idx] ?? 0;
+    }
+
+    set_n_A_HEAD_DEF_PLUS(model.defPlus.head);
+    set_n_A_BODY_DEF_PLUS(model.defPlus.body);
+    set_n_A_SHIELD_DEF_PLUS(model.defPlus.shield);
+    set_n_A_SHOULDER_DEF_PLUS(model.defPlus.shoulder);
+    set_n_A_SHOES_DEF_PLUS(model.defPlus.shoes);
+
+    // シャドウ装備データ（g_shadowEquipController 自身の内部状態。境界の外側）
+    set_g_itemIdArray([]);
+    set_g_refinedArray([]);
+    if ((typeof g_shadowEquipController) !== "undefined") {
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_ARMS_RIGHT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_ARMS_LEFT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_BODY] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_BODY);
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_FOOT] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_FOOT);
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_1] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
+        g_itemIdArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_2] = g_shadowEquipController.getEquippedID(CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
+
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_ARMS_RIGHT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_ARMS_LEFT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_BODY] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_BODY);
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_FOOT] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_FOOT);
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_1] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
+        g_refinedArray[EQUIP_REGION_ID_SHADOW_ACCESSORY_2] = g_shadowEquipController.getRefined(CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
+
+        const funcSetRndOptTable = (eqpRgnIdF, eqpRgnNameF) => {
+            const rndOptInfoArrayF = g_shadowEquipController.getRndOptInfoArray(eqpRgnNameF);
+            for (let idxF = 0; idxF < rndOptInfoArrayF.length; idxF++) {
+                SetEquipRndOptTable(eqpRgnIdF, idxF, rndOptInfoArrayF[idxF][0], rndOptInfoArrayF[idxF][1]);
+            }
+        };
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ARMS_RIGHT, CShadowEquipController.EQPRGN_NAME_ARMS_RIGHT);
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ARMS_LEFT, CShadowEquipController.EQPRGN_NAME_ARMS_LEFT);
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_BODY, CShadowEquipController.EQPRGN_NAME_BODY);
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_FOOT, CShadowEquipController.EQPRGN_NAME_FOOT);
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ACCESSORY_1, CShadowEquipController.EQPRGN_NAME_ACCESSORY_1);
+        funcSetRndOptTable(EQUIP_REGION_ID_SHADOW_ACCESSORY_2, CShadowEquipController.EQPRGN_NAME_ACCESSORY_2);
+    }
+
+    // 超越段階
+    set_n_A_Weapon_Transcendence(model.weapon.transcendence);
+    set_n_A_Weapon2_Transcendence(model.weapon.weapon2Transcendence);
+    set_n_A_HEAD_DEF_Transcendence(model.defTranscendence.head);
+    set_n_A_SHIELD_DEF_Transcendence(model.defTranscendence.shield);
+    set_n_A_BODY_DEF_Transcendence(model.defTranscendence.body);
+    set_n_A_SHOULDER_DEF_Transcendence(model.defTranscendence.shoulder);
+    set_n_A_SHOES_DEF_Transcendence(model.defTranscendence.shoes);
+
+    //----------------------------------------------------------------
+    // 攻撃手段を設定する（CAttackMethodAreaComponentManager 自身の内部状態。境界の外側）
+    //----------------------------------------------------------------
+    const attackMethodConf = CAttackMethodAreaComponentManager.GetAttackMethodConf();
+
+    set_n_A_ActiveSkill(attackMethodConf.GetSkillId());
+    set_n_A_ActiveSkillLV(attackMethodConf.GetSkillLv());
+
+    const attackMethodConfArray = [attackMethodConf];
+
+    set_n_A_WeaponLV(Math.floor(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS]][ITEM_DATA_INDEX_WPNLV] % 10));
+
+    // 従来の処理
+    set_n_A_Weapon_ATK(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS]][ITEM_DATA_INDEX_POWER]);
+
+    set_n_A_Weapon_ATKplus(model.weapon.atkPlus);
+    set_n_A_WeaponLV_seirenATK(0);
+    set_n_A_WeaponLV_Minplus(0);
+    set_n_A_WeaponLV_Maxplus(0);
+    if(n_A_WeaponLV == 1){
+        set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 2);
+        if(n_A_Weapon_ATKplus >= 8){
+            set_n_A_WeaponLV_Minplus(1);
+            set_n_A_WeaponLV_Maxplus(3 * (n_A_Weapon_ATKplus - 7));
+        }
+    }else if(n_A_WeaponLV == 2){
+        set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 3);
+        if(n_A_Weapon_ATKplus >= 7){
+            set_n_A_WeaponLV_Minplus(1);
+            set_n_A_WeaponLV_Maxplus(5 * (n_A_Weapon_ATKplus - 6));
+        }
+    }else if(n_A_WeaponLV == 3){
+        set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 5);
+        if(n_A_Weapon_ATKplus >= 6){
+            set_n_A_WeaponLV_Minplus(1);
+            set_n_A_WeaponLV_Maxplus(8 * (n_A_Weapon_ATKplus - 5));
+        }
+    }else if(n_A_WeaponLV == 4){
+        set_n_A_WeaponLV_seirenATK(n_A_Weapon_ATKplus * 7);
+        if(n_A_Weapon_ATKplus >= 5){
+            set_n_A_WeaponLV_Minplus(1);
+            set_n_A_WeaponLV_Maxplus(14 * (n_A_Weapon_ATKplus - 4));
+        }
+    }
+
+    set_n_A_Weapon2_ATKplus(0);
+    if (n_Nitou) {
+        set_n_A_Weapon2LV(Math.floor(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS_LEFT]][ITEM_DATA_INDEX_WPNLV] % 10));
+
+        set_n_A_Weapon2_ATK(ItemObjNew[n_A_Equip[EQUIP_REGION_ID_ARMS_LEFT]][ITEM_DATA_INDEX_POWER]);
+
+        set_n_A_Weapon2_ATKplus(model.weapon.weapon2AtkPlus);
+        set_n_A_Weapon2LV_seirenATK(0);
+        set_n_A_Weapon2LV_Minplus(0);
+        set_n_A_Weapon2LV_Maxplus(0);
+        if(n_A_Weapon2LV == 1){
+            set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 2);
+            if(n_A_Weapon2_ATKplus >= 8){
+                set_n_A_Weapon2LV_Minplus(1);
+                set_n_A_Weapon2LV_Maxplus(3 * (n_A_Weapon2_ATKplus - 7));
+            }
+        }else if(n_A_Weapon2LV == 2){
+            set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 3);
+            if(n_A_Weapon2_ATKplus >= 7){
+                set_n_A_Weapon2LV_Minplus(1);
+                set_n_A_Weapon2LV_Maxplus(5 * (n_A_Weapon2_ATKplus - 6));
+            }
+        }else if(n_A_Weapon2LV == 3){
+            set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 5);
+            if(n_A_Weapon2_ATKplus >= 6){
+                set_n_A_Weapon2LV_Minplus(1);
+                set_n_A_Weapon2LV_Maxplus(8 * (n_A_Weapon2_ATKplus - 5));
+            }
+        }else if(n_A_Weapon2LV == 4){
+            set_n_A_Weapon2LV_seirenATK(n_A_Weapon2_ATKplus * 7);
+            if(n_A_Weapon2_ATKplus >= 5){
+                set_n_A_Weapon2LV_Minplus(1);
+                set_n_A_Weapon2LV_Maxplus(14 * (n_A_Weapon2_ATKplus - 4));
+            }
+        }
+    }
+
+    //----------------------------------------------------------------
+    // 装着カードを設定する
+    //----------------------------------------------------------------
+    for (let cardIdx = 0; cardIdx < CARD_REGION_ID_COUNT; cardIdx++) {
+        n_A_card[cardIdx] = model.card[cardIdx] ?? 0;
+    }
+
+    //----------------------------------------------------------------
+    // 装着衣装を設定する
+    //----------------------------------------------------------------
+    for (let costumeIdx = 0; costumeIdx < COSTUME_REGION_ID_COUNT; costumeIdx++) {
+        n_A_costume[costumeIdx] = model.costume[costumeIdx] ?? 0;
+    }
+
+    const passiveSkillIdArray = g_constDataManager.GetDataObject(CONST_DATA_KIND_JOB, n_A_JOB).GetPassiveSkillIdArray();
+
+    if(n_Skill1SW){
+        for(let i = 0; i < passiveSkillIdArray.length; i++){
+            if (model.passiveSkill[i] !== null) {
+                n_A_PassSkill[i] = model.passiveSkill[i];
+            }
+        }
+    }
+
+    if(n_Skill4SW){
+        n_A_PassSkill4[0] = model.buff4[0];
+        n_A_PassSkill4[1] = model.buff4[1];
+        n_A_PassSkill4[2] = model.buff4[2];
+        n_A_PassSkill4[3] = model.buff4[3];
+        n_A_PassSkill4[4] = model.buff4[4];
+        n_A_PassSkill4[5] = model.buff4[5];
+        n_A_PassSkill4[6] = model.buff4[6];
+        n_A_PassSkill4[7] = model.buff4[7];
+        n_A_PassSkill4[8] = model.buff4[8];
+        n_A_PassSkill4[9] = model.buff4[9];
+        n_A_PassSkill4[10] = model.buff4[10];
+        n_A_PassSkill4[11] = model.buff4[11];
+        n_A_PassSkill4[30] = model.buff4[30];
+        n_A_PassSkill4[31] = model.buff4[31];
+        n_A_PassSkill4[32] = model.buff4[32];
+        n_A_PassSkill4[33] = model.buff4[33];
+        n_A_PassSkill4[34] = model.buff4[34];
+        n_A_PassSkill4[35] = model.buff4[35];
+    }
+
+    // オートスペル設定の反映
+    for (let idx = 0; idx < AUTO_SPELL_SETTING_COUNT; idx++) {
+        if (model.autoSpell[OBJID_OFFSET_AS_SKILL_ID + idx] !== null) {
+            n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_ID + idx] = model.autoSpell[OBJID_OFFSET_AS_SKILL_ID + idx];
+        }
+        if (model.autoSpell[OBJID_OFFSET_AS_SKILL_LV + idx] !== null) {
+            n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_LV + idx] = model.autoSpell[OBJID_OFFSET_AS_SKILL_LV + idx];
+        }
+        if (model.autoSpell[OBJID_OFFSET_AS_SKILL_PROB + idx] !== null) {
+            n_A_PassSkill5[OBJID_OFFSET_AS_SKILL_PROB + idx] = model.autoSpell[OBJID_OFFSET_AS_SKILL_PROB + idx];
+        }
+    }
+
+    // アイテム(食品/他) の反映
+    if(n_Skill7SW){
+        for (let i = 0; i <= 52; i++) {
+            n_A_PassSkill7[i] = model.buff7[i];
+        }
+    }
+    n_A_PassSkill8[14] = 0;
+    if(n_Skill8SW){
+        n_A_PassSkill8[0] = model.buff8[0];
+        n_A_PassSkill8[1] = model.buff8[1];
+        n_A_PassSkill8[2] = model.buff8[2];
+        n_A_PassSkill8[3] = model.buff8[3];
+        n_A_PassSkill8[4] = model.buff8[4];
+        n_A_PassSkill8[5] = model.buff8[5];
+        n_A_PassSkill8[6] = model.buff8[6];
+        n_A_PassSkill8[7] = model.buff8[7];
+        n_A_PassSkill8[12] = model.buff8[12];
+        n_A_PassSkill8[13] = model.buff8[13];
+        n_A_PassSkill8[15] = model.buff8[15];
+        n_A_PassSkill8[16] = model.buff8[16];
+        n_A_PassSkill8[17] = model.buff8[17];
+        n_A_PassSkill8[19] = model.buff8[19];
+        n_A_PassSkill8[21] = model.buff8[21];
+        n_A_PassSkill8[22] = model.buff8[22];
+    }
+
+    return { attackMethodConfArray };
+}
+
+/**
+ * StAllCalc の DOM 走査プロローグ本体（後方互換ラッパー）。
+ * `ExtractModelFromDom()` → `HydrateFromModel()` を素通しで呼ぶだけ。
+ * `ID_A_HUYO_NAME` のラベル書き換えのみ、モデルに属さない純粋な表示側の副作用のため
+ * ここに残す（HydrateFromModel はDOMを一切書かない）。
+ * StAllCalcCore() 側でも必要な n_A_SpeedPOT と attackMethodConfArray のみ戻り値として返す。
+ */
+export function HydrateFromDom() {
+    const model = ExtractModelFromDom();
+    const { attackMethodConfArray } = HydrateFromModel(model);
+
+    if(n_Skill8SW){
+        if(41 <= n_A_JOB && n_A_JOB <= 43){
+            if(n_A_PassSkill8[19] == 0) document.getElementById("ID_A_HUYO_NAME").textContent = "暖かい風";
+            else document.getElementById("ID_A_HUYO_NAME").textContent = "武器属性付与";
+        }
+    }
+
+    return { n_A_SpeedPOT: model.status.speedPot, attackMethodConfArray };
 }

--- a/roro/m/js/roro-state.js
+++ b/roro/m/js/roro-state.js
@@ -140,7 +140,7 @@ export let n_A_card = [];
 export function set_n_A_Equip(v) { n_A_Equip = v; }
 export function set_n_A_card(v) { n_A_card = v; }
 
-// Phase 2b: UpdateEquipItemDataByHtml() が書き込み、StAllCalc の
+// Phase 2b: foot-stallcalc-hydrate.js の HydrateFromModel() が書き込み、StAllCalc の
 // ATKの算出（foot-stallcalc-atk-base.js）が読む値のため移設。
 export let n_A_WeaponZokusei = 0;
 export function set_n_A_WeaponZokusei(v) { n_A_WeaponZokusei = v; }

--- a/tests/helpers/objid-snapshot.ts
+++ b/tests/helpers/objid-snapshot.ts
@@ -252,6 +252,10 @@ const STATE_MODULE_PATHS = [
     '/roro/m/js/mobconfplayer.js',
     '/roro/m/js/mobconfbuf.js',
     '/ro4/m/js/hmjob.js',
+    // Phase 8（リファクタリング計画）で追加: n_A_PassSkill/3/4/7/8（バフ配列5本）の
+    // owner。Phase 6でOBJID化した約110入力の書き込み先だが、それまでこの一覧に
+    // 含まれておらずモデル導入の検証（二重hydration差分）の死角になっていた。
+    '/ro4/m/js/skillstate.js',
 ] as const;
 
 /**


### PR DESCRIPTION
foot-stallcalc-hydrate.jsのHydrateFromDom()を、DOM→モデル(ExtractModelFromDom) とモデル→グローバル(HydrateFromModel)に分離。calc-model.jsにプレーンな モデル定義を新設。境界は「hydrate.js自身が直接DOMを読む値」のみとし、 職業選択・バフパネル開閉・攻撃手段・シャドウ装備等の他コンポーネント 依存は境界の外側とした。11フィクスチャでsnapshotAllGlobals()の 差分ゼロを確認。未使用だったUpdateEquip*ByHtml3関数は削除。 Phase 9(headless API)の前提条件。